### PR TITLE
feat(CORV-8): add GTest suite — 26 tests across version, health handler, and router

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ find_package(GTest CONFIG REQUIRED)
 # ── Include dirs ───────────────────────────────────────────────────────────
 include_directories(include)
 
+# ── Testing ────────────────────────────────────────────────────────────────
+enable_testing()
+
 # ── Subdirectories ─────────────────────────────────────────────────────────
 add_subdirectory(src)
 add_subdirectory(tests/unit)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,24 @@
-set(GATEWAY_SOURCES
+add_library(corvus-gateway STATIC
   gateway/router.cpp
   gateway/health_handler.cpp
 )
 
+target_include_directories(corvus-gateway PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+)
+ 
+target_link_libraries(corvus-gateway PUBLIC
+  Drogon::Drogon
+)
+ 
+target_compile_features(corvus-gateway PUBLIC cxx_std_20)
+
 add_executable(corvus-core
   main.cpp
-  ${GATEWAY_SOURCES}
-)
-
-target_include_directories(corvus-core PRIVATE
-  ${CMAKE_SOURCE_DIR}/include
 )
 
 target_link_libraries(corvus-core PRIVATE
-  Drogon::Drogon
+  corvus-gateway
 )
 
 target_compile_features(corvus-core PRIVATE cxx_std_20)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,8 +1,7 @@
-enable_testing()
-
 add_executable(corvus-unit-tests
   test_version.cpp
   test_health_handler.cpp
+  test_router.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -10,12 +9,21 @@ target_include_directories(corvus-unit-tests PRIVATE
 )
 
 target_link_libraries(corvus-unit-tests PRIVATE
+  corvus-gateway
   GTest::gtest
   GTest::gtest_main
+  GTest::gmock
   Drogon::Drogon
 )
 
 target_compile_features(corvus-unit-tests PRIVATE cxx_std_20)
 
 include(GoogleTest)
-gtest_discover_tests(corvus-unit-tests)
+
+gtest_add_tests(
+  TARGET      corvus-unit-tests
+  SOURCES     test_version.cpp
+              test_health_handler.cpp
+              test_router.cpp
+)
+

--- a/tests/unit/test_health_handler.cpp
+++ b/tests/unit/test_health_handler.cpp
@@ -1,12 +1,152 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include "corvus/version.h"
+#include "corvus/gateway/health_handler.h"
+#include <drogon/drogon.h>
+#include <json/json.h>
 
 namespace
 {
-
-    TEST(HealthHandlerTest, VersionStringAvailableToHandler)
+    struct HandlerResult
     {
-        EXPECT_EQ(corvus::version::string(), "0.1.0");
+        drogon::HttpResponsePtr response;
+        bool called{false};
+    };
+
+    HandlerResult invoke_handler(const std::string &path)
+    {
+        HandlerResult result;
+
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath(path);
+        req->setMethod(drogon::Get);
+
+        auto handler = corvus::gateway::health_handler();
+        handler(req, [&result](const drogon::HttpResponsePtr &resp)
+                {
+            result.response = resp;
+            result.called = true; });
+        return result;
+    }
+    Json::Value parse_body(const drogon::HttpResponsePtr &resp)
+    {
+
+        Json::Value root;
+        Json::Reader reader;
+        reader.parse(std::string(resp->getBody()), root);
+        return root;
+    }
+
+    TEST(HealthHandlerTest, CallbackIsAlwaysInvoked)
+    {
+        const auto result = invoke_handler("/health");
+        EXPECT_TRUE(result.called);
+    }
+
+    TEST(HealthHandlerTest, CallbackIsInvokedForReadyPath)
+    {
+        const auto result = invoke_handler("/ready");
+        EXPECT_TRUE(result.called);
+    }
+
+    TEST(HealthHandlerTest, ReturnsHttp200ForHealth)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        EXPECT_EQ(result.response->getStatusCode(), drogon::k200OK);
+    }
+
+    TEST(HealthHandlerTest, ReturnsHttp200ForReady)
+    {
+        const auto result = invoke_handler("/ready");
+        ASSERT_TRUE(result.called);
+        EXPECT_EQ(result.response->getStatusCode(), drogon::k200OK);
+    }
+
+    TEST(HealthHandlerTest, BodyContainsStatusOk)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        ASSERT_TRUE(body.isMember("status"));
+        EXPECT_EQ(body["status"].asString(), "ok");
+    }
+
+    TEST(HealthHandlerTest, BodyStatusIsOkForReadyEndpoint)
+    {
+        const auto result = invoke_handler("/ready");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        EXPECT_EQ(body["status"].asString(), "ok");
+    }
+
+    TEST(HealthHandlerTest, BodyContainsVersionField)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        ASSERT_TRUE(body.isMember("version"));
+        EXPECT_FALSE(body["version"].asString().empty());
+    }
+
+    TEST(HealthHandlerTest, BodyVersionMatchesCurrentVersion)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        EXPECT_EQ(body["version"].asString(),
+                  std::string{corvus::version::string()});
+    }
+
+    TEST(HealthHandlerTest, BodyContainsPathField)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        ASSERT_TRUE(body.isMember("path"));
+    }
+
+    TEST(HealthHandlerTest, BodyPathMatchesRequestPathForHealth)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        EXPECT_EQ(body["path"].asString(), "/health");
+    }
+
+    TEST(HealthHandlerTest, BodyPathMatchesRequestPathForReady)
+    {
+        const auto result = invoke_handler("/ready");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        EXPECT_EQ(body["path"].asString(), "/ready");
+    }
+
+    TEST(HealthHandlerTest, BodyContainsAllRequiredFields)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto body = parse_body(result.response);
+        EXPECT_TRUE(body.isMember("status"));
+        EXPECT_TRUE(body.isMember("version"));
+        EXPECT_TRUE(body.isMember("path"));
+    }
+
+    TEST(HealthHandlerTest, HandlerCanBeInvokedMultipleTimes)
+    {
+        auto handler = corvus::gateway::health_handler();
+
+        for (int i = 0; i < 5; ++i)
+        {
+            bool called = false;
+            auto req = drogon::HttpRequest::newHttpRequest();
+            req->setPath("/health");
+            handler(req, [&called](const drogon::HttpResponsePtr &resp)
+                    {
+            called = true;
+            EXPECT_EQ(resp->getStatusCode(), drogon::k200OK); });
+            EXPECT_TRUE(called) << "Handler not called on iteration " << i;
+        }
     }
 
 } // namespace

--- a/tests/unit/test_router.cpp
+++ b/tests/unit/test_router.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "corvus/gateway/router.h"
+#include "corvus/gateway/health_handler.h"
+#include <drogon/drogon.h>
+
+namespace
+{
+
+    TEST(RouterTest, HealthHandlerFactoryReturnsNonNullCallable)
+    {
+        auto handler = corvus::gateway::health_handler();
+        EXPECT_TRUE(static_cast<bool>(handler));
+    }
+
+    TEST(RouterTest, HealthHandlerFactoryReturnsDifferentInstancesEachCall)
+    {
+        auto h1 = corvus::gateway::health_handler();
+        auto h2 = corvus::gateway::health_handler();
+        EXPECT_TRUE(static_cast<bool>(h1));
+        EXPECT_TRUE(static_cast<bool>(h2));
+    }
+
+    TEST(RouterTest, HealthHandlerIsCallableWithValidRequest)
+    {
+        auto handler = corvus::gateway::health_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/health");
+
+        bool callback_invoked = false;
+        handler(req, [&callback_invoked](const drogon::HttpResponsePtr &resp)
+                {
+                    callback_invoked = true;
+                    EXPECT_NE(resp, nullptr);
+                });
+
+        EXPECT_TRUE(callback_invoked);
+    }
+} //namespace

--- a/tests/unit/test_version.cpp
+++ b/tests/unit/test_version.cpp
@@ -9,16 +9,66 @@ namespace
         EXPECT_FALSE(corvus::version::string().empty());
     }
 
-    TEST(VersionTest, MajorMinorPatchAreNonNegative)
+    TEST(VersionTest, StringMatchesMajorMinorPatch)
+    {
+        const auto v = std::string{corvus::version::string()};
+
+        const auto expected = std::to_string(corvus::version::major_v) + "." +
+                              std::to_string(corvus::version::minor_v) + "." +
+                              std::to_string(corvus::version::patch_v);
+
+        EXPECT_EQ(v, expected);
+    }
+
+    TEST(VersionTest, StringContainsTwoDots)
+    {
+        const auto v = std::string{corvus::version::string()};
+        const auto dot_count = std::count(v.begin(), v.end(), '.');
+        EXPECT_EQ(dot_count, 2);
+    }
+
+    TEST(VersionTest, StringHasNoLeadingOrTrailingWhitespace)
+    {
+        const auto v = std::string{corvus::version::string()};
+        EXPECT_NE(v.front(), ' ');
+        EXPECT_NE(v.back(), ' ');
+    }
+
+    TEST(VersionTest, MajorIsNonNegative)
     {
         EXPECT_GE(corvus::version::major_v, 0);
+    }
+
+    TEST(VersionTest, MinorIsNonNegative)
+    {
         EXPECT_GE(corvus::version::minor_v, 0);
+    }
+
+    TEST(VersionTest, PatchIsNonNegative)
+    {
         EXPECT_GE(corvus::version::patch_v, 0);
     }
 
-    TEST(VersionTest, StringIsCorrectVersion)
+    TEST(VersionTest, CurrentVersionIs010)
     {
+        EXPECT_EQ(corvus::version::major_v, 0);
+        EXPECT_EQ(corvus::version::minor_v, 1);
+        EXPECT_EQ(corvus::version::patch_v, 0);
         EXPECT_EQ(corvus::version::string(), "0.1.0");
+    }
+
+    TEST(VersionTest, StringIsUsableAtCompileTime)
+    {
+        constexpr auto v = corvus::version::string();
+        EXPECT_FALSE(v.empty());
+    }
+
+    TEST(VersionTest, ComponentsAreUsableAtCompileTime)
+    {
+        constexpr int major = corvus::version::major_v;
+        constexpr int minor = corvus::version::minor_v;
+        constexpr int patch = corvus::version::patch_v;
+        EXPECT_GE(major + minor + patch, 0);
     }
 
 } // namespace


### PR DESCRIPTION
Closes CORV-8

## What
- Extracted gateway sources into corvus-gateway static library
- Added 26 unit tests across 3 suites: VersionTest, HealthHandlerTest, RouterTest
- Moved enable_testing() to root CMakeLists.txt
- Switched to gtest_add_tests for reliable test discovery without binary execution

## Verification
100% tests passed, 0 tests failed out of 26
Total Test time: 4.35 sec