### PR TITLE
feat(CORV-13): add request/response envelope structs

### DIFF
--- a/include/corvus/api/envelope.h
+++ b/include/corvus/api/envelope.h
@@ -1,0 +1,158 @@
+#pragma once
+#include <json/json.h>
+#include <string>
+#include <optional>
+#include <chrono>
+#include <format>
+
+namespace corvus::api
+{
+
+    // ── ApiError ───────────────────────────────────────────────────────────────
+
+    /// Machine-readable error codes returned in the error envelope.
+    /// Add new codes here as the API grows — never use raw strings in handlers.
+    enum class ErrorCode
+    {
+        // Generic
+        internal_error,
+        not_found,
+        bad_request,
+        unauthorized,
+        forbidden,
+        conflict,
+        too_many_requests,
+        unprocessable_entity,
+        resource_not_found,
+        resource_already_exists,
+        resource_invalid_state,
+        quota_exceeded,
+        policy_denied,
+    };
+
+    /// Convert an ErrorCode to its canonical string representation.
+    inline std::string to_string(ErrorCode code)
+    {
+        switch (code)
+        {
+        case ErrorCode::internal_error:
+            return "INTERNAL_ERROR";
+        case ErrorCode::not_found:
+            return "NOT_FOUND";
+        case ErrorCode::bad_request:
+            return "BAD_REQUEST";
+        case ErrorCode::unauthorized:
+            return "UNAUTHORIZED";
+        case ErrorCode::forbidden:
+            return "FORBIDDEN";
+        case ErrorCode::conflict:
+            return "CONFLICT";
+        case ErrorCode::too_many_requests:
+            return "TOO_MANY_REQUESTS";
+        case ErrorCode::unprocessable_entity:
+            return "UNPROCESSABLE_ENTITY";
+        case ErrorCode::resource_not_found:
+            return "RESOURCE_NOT_FOUND";
+        case ErrorCode::resource_already_exists:
+            return "RESOURCE_ALREADY_EXISTS";
+        case ErrorCode::resource_invalid_state:
+            return "RESOURCE_INVALID_STATE";
+        case ErrorCode::quota_exceeded:
+            return "QUOTA_EXCEEDED";
+        case ErrorCode::policy_denied:
+            return "POLICY_DENIED";
+        default:
+            return "UNKNOWN_ERROR";
+        }
+    }
+
+    /// Structured error returned in the envelope when a request fails.
+    struct ApiError
+    {
+        ErrorCode code;
+        std::string message;
+        Json::Value details{Json::objectValue};
+
+        Json::Value to_json() const
+        {
+            Json::Value obj{Json::objectValue};
+            obj["code"] = to_string(code);
+            obj["message"] = message;
+            if (!details.empty())
+            {
+                obj["details"] = details;
+            }
+            return obj;
+        }
+    };
+
+    // ── Meta ───────────────────────────────────────────────────────────────────
+
+    struct Meta
+    {
+        std::string request_id;
+        std::string timestamp;
+        std::optional<std::string> next_cursor;
+        std::optional<bool> has_more;
+
+        Json::Value to_json() const
+        {
+            Json::Value obj{Json::objectValue};
+            obj["request_id"] = request_id;
+            obj["timestamp"] = timestamp;
+
+            if (next_cursor.has_value())
+            {
+                obj["next_cursor"] = next_cursor.value();
+            }
+            if (has_more.has_value())
+            {
+                obj["has_more"] = has_more.value();
+            }
+            return obj;
+        }
+    };
+
+    // ── Envelope ───────────────────────────────────────────────────────────────
+
+    /// The standard JSON envelope wrapping every Corvus API response.
+    ///
+    /// Success: { "data": {...}, "error": null, "meta": {...} }
+    /// Error:   { "data": null,  "error": {...}, "meta": {...} }
+    struct Envelope
+    {
+        Json::Value data{Json::nullValue};
+        std::optional<ApiError> error;
+        Meta meta;
+
+        Json::Value to_json() const
+        {
+            Json::Value obj{Json::objectValue};
+            obj["data"] = data;
+            obj["error"] = error.has_value()
+                               ? error->to_json()
+                               : Json::Value{Json::nullValue};
+            obj["meta"] = meta.to_json();
+            return obj;
+        }
+    };
+
+    // ── Builder helpers ────────────────────────────────────────────────────────
+    // Use these in handlers — never construct Envelope directly.
+
+    /// Build a success envelope with a data payload.
+    Envelope ok(Json::Value data, const std::string &request_id);
+
+    /// Build a success envelope for paginated list responses.
+    Envelope ok_list(Json::Value data,
+                     const std::string &request_id,
+                     std::optional<std::string> next_cursor = std::nullopt,
+                     bool has_more = false);
+
+    /// Build an error envelope.
+    Envelope error(ErrorCode code,
+                   const std::string &message,
+                   const std::string &request_id,
+                   Json::Value details = Json::Value{Json::objectValue});
+
+} // namespace corvus::api

--- a/include/corvus/api/envelope.h
+++ b/include/corvus/api/envelope.h
@@ -1,158 +1,153 @@
 #pragma once
-#include <json/json.h>
-#include <string>
-#include <optional>
 #include <chrono>
-#include <format>
+#include <json/json.h>
+#include <optional>
+#include <string>
 
 namespace corvus::api
 {
 
-    // ── ApiError ───────────────────────────────────────────────────────────────
+  //  ApiError
 
-    /// Machine-readable error codes returned in the error envelope.
-    /// Add new codes here as the API grows — never use raw strings in handlers.
-    enum class ErrorCode
-    {
-        // Generic
-        internal_error,
-        not_found,
-        bad_request,
-        unauthorized,
-        forbidden,
-        conflict,
-        too_many_requests,
-        unprocessable_entity,
-        resource_not_found,
-        resource_already_exists,
-        resource_invalid_state,
-        quota_exceeded,
-        policy_denied,
-    };
+  /// Machine-readable error codes returned in the error envelope.
+  /// Add new codes here as the API grows — never use raw strings in handlers.
+  enum class ErrorCode
+  {
+    internal_error,
+    not_found,
+    bad_request,
+    unauthorized,
+    forbidden,
+    conflict,
+    too_many_requests,
+    unprocessable_entity,
+    resource_not_found,
+    resource_already_exists,
+    resource_invalid_state,
+    quota_exceeded,
+    policy_denied,
+  };
 
-    /// Convert an ErrorCode to its canonical string representation.
-    inline std::string to_string(ErrorCode code)
+  /// Convert an ErrorCode to its canonical string representation.
+  inline std::string to_string(ErrorCode code)
+  {
+    switch (code)
     {
-        switch (code)
-        {
-        case ErrorCode::internal_error:
-            return "INTERNAL_ERROR";
-        case ErrorCode::not_found:
-            return "NOT_FOUND";
-        case ErrorCode::bad_request:
-            return "BAD_REQUEST";
-        case ErrorCode::unauthorized:
-            return "UNAUTHORIZED";
-        case ErrorCode::forbidden:
-            return "FORBIDDEN";
-        case ErrorCode::conflict:
-            return "CONFLICT";
-        case ErrorCode::too_many_requests:
-            return "TOO_MANY_REQUESTS";
-        case ErrorCode::unprocessable_entity:
-            return "UNPROCESSABLE_ENTITY";
-        case ErrorCode::resource_not_found:
-            return "RESOURCE_NOT_FOUND";
-        case ErrorCode::resource_already_exists:
-            return "RESOURCE_ALREADY_EXISTS";
-        case ErrorCode::resource_invalid_state:
-            return "RESOURCE_INVALID_STATE";
-        case ErrorCode::quota_exceeded:
-            return "QUOTA_EXCEEDED";
-        case ErrorCode::policy_denied:
-            return "POLICY_DENIED";
-        default:
-            return "UNKNOWN_ERROR";
-        }
+    case ErrorCode::internal_error:
+      return "INTERNAL_ERROR";
+    case ErrorCode::not_found:
+      return "NOT_FOUND";
+    case ErrorCode::bad_request:
+      return "BAD_REQUEST";
+    case ErrorCode::unauthorized:
+      return "UNAUTHORIZED";
+    case ErrorCode::forbidden:
+      return "FORBIDDEN";
+    case ErrorCode::conflict:
+      return "CONFLICT";
+    case ErrorCode::too_many_requests:
+      return "TOO_MANY_REQUESTS";
+    case ErrorCode::unprocessable_entity:
+      return "UNPROCESSABLE_ENTITY";
+    case ErrorCode::resource_not_found:
+      return "RESOURCE_NOT_FOUND";
+    case ErrorCode::resource_already_exists:
+      return "RESOURCE_ALREADY_EXISTS";
+    case ErrorCode::resource_invalid_state:
+      return "RESOURCE_INVALID_STATE";
+    case ErrorCode::quota_exceeded:
+      return "QUOTA_EXCEEDED";
+    case ErrorCode::policy_denied:
+      return "POLICY_DENIED";
+    default:
+      return "UNKNOWN_ERROR";
     }
+  }
 
-    /// Structured error returned in the envelope when a request fails.
-    struct ApiError
+  /// Structured error returned in the envelope when a request fails.
+  struct ApiError
+  {
+    ErrorCode code;
+    std::string message;
+    Json::Value details{Json::objectValue}; // optional extra context
+
+    Json::Value to_json() const
     {
-        ErrorCode code;
-        std::string message;
-        Json::Value details{Json::objectValue};
+      Json::Value obj{Json::objectValue};
+      obj["code"] = to_string(code);
+      obj["message"] = message;
+      if (!details.empty())
+      {
+        obj["details"] = details;
+      }
+      return obj;
+    }
+  };
 
-        Json::Value to_json() const
-        {
-            Json::Value obj{Json::objectValue};
-            obj["code"] = to_string(code);
-            obj["message"] = message;
-            if (!details.empty())
-            {
-                obj["details"] = details;
-            }
-            return obj;
-        }
-    };
+  //  Meta
 
-    // ── Meta ───────────────────────────────────────────────────────────────────
+  /// Metadata attached to every response.
+  struct Meta
+  {
+    std::string request_id;
+    std::string timestamp;                  // ISO 8601
+    std::optional<std::string> next_cursor; // pagination
+    std::optional<bool> has_more;           // pagination
 
-    struct Meta
+    Json::Value to_json() const
     {
-        std::string request_id;
-        std::string timestamp;
-        std::optional<std::string> next_cursor;
-        std::optional<bool> has_more;
+      Json::Value obj{Json::objectValue};
+      obj["request_id"] = request_id;
+      obj["timestamp"] = timestamp;
 
-        Json::Value to_json() const
-        {
-            Json::Value obj{Json::objectValue};
-            obj["request_id"] = request_id;
-            obj["timestamp"] = timestamp;
+      if (next_cursor.has_value())
+      {
+        obj["next_cursor"] = next_cursor.value();
+      }
+      if (has_more.has_value())
+      {
+        obj["has_more"] = has_more.value();
+      }
+      return obj;
+    }
+  };
 
-            if (next_cursor.has_value())
-            {
-                obj["next_cursor"] = next_cursor.value();
-            }
-            if (has_more.has_value())
-            {
-                obj["has_more"] = has_more.value();
-            }
-            return obj;
-        }
-    };
+  //  Envelope
 
-    // ── Envelope ───────────────────────────────────────────────────────────────
+  /// The standard JSON envelope wrapping every Corvus API response.
+  /// Success: { "data": {...}, "error": null, "meta": {...} }
+  /// Error:   { "data": null,  "error": {...}, "meta": {...} }
 
-    /// The standard JSON envelope wrapping every Corvus API response.
-    ///
-    /// Success: { "data": {...}, "error": null, "meta": {...} }
-    /// Error:   { "data": null,  "error": {...}, "meta": {...} }
-    struct Envelope
+  struct Envelope
+  {
+    Json::Value data{Json::nullValue};
+    std::optional<ApiError> error;
+    Meta meta;
+
+    Json::Value to_json() const
     {
-        Json::Value data{Json::nullValue};
-        std::optional<ApiError> error;
-        Meta meta;
+      Json::Value obj{Json::objectValue};
+      obj["data"] = data;
+      obj["error"] =
+          error.has_value() ? error->to_json() : Json::Value{Json::nullValue};
+      obj["meta"] = meta.to_json();
+      return obj;
+    }
+  };
 
-        Json::Value to_json() const
-        {
-            Json::Value obj{Json::objectValue};
-            obj["data"] = data;
-            obj["error"] = error.has_value()
-                               ? error->to_json()
-                               : Json::Value{Json::nullValue};
-            obj["meta"] = meta.to_json();
-            return obj;
-        }
-    };
+  //  Builder helpers
 
-    // ── Builder helpers ────────────────────────────────────────────────────────
-    // Use these in handlers — never construct Envelope directly.
+  /// Build a success envelope with a data payload.
+  Envelope ok(Json::Value data, const std::string &request_id);
 
-    /// Build a success envelope with a data payload.
-    Envelope ok(Json::Value data, const std::string &request_id);
+  /// Build a success envelope for paginated list responses.
+  Envelope ok_list(Json::Value data, const std::string &request_id,
+                   std::optional<std::string> next_cursor = std::nullopt,
+                   bool has_more = false);
 
-    /// Build a success envelope for paginated list responses.
-    Envelope ok_list(Json::Value data,
-                     const std::string &request_id,
-                     std::optional<std::string> next_cursor = std::nullopt,
-                     bool has_more = false);
-
-    /// Build an error envelope.
-    Envelope error(ErrorCode code,
-                   const std::string &message,
-                   const std::string &request_id,
-                   Json::Value details = Json::Value{Json::objectValue});
+  /// Build an error envelope.
+  Envelope error(ErrorCode code, const std::string &message,
+                 const std::string &request_id,
+                 Json::Value details = Json::Value{Json::objectValue});
 
 } // namespace corvus::api

--- a/include/corvus/api/request_id.h
+++ b/include/corvus/api/request_id.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <drogon/drogon.h>
+#include <string>
+
+namespace corvus::api
+{
+
+    /// Key used to store the request ID in drogon request attributes
+    inline constexpr const char *kRequestIdKey = "corvus-request-id";
+
+    /// Extract the request ID previously injected by RequestIdFilter
+    std::string get_request_id(const drogon::HttpRequestPtr &req);
+
+    /// Generate a new UUID v4 string
+    std::string generate_uuid();
+
+} // namespace corvus::api

--- a/include/corvus/api/response.h
+++ b/include/corvus/api/response.h
@@ -5,57 +5,57 @@
 namespace corvus::api
 {
 
-    /// HTTP status codes mapped to each ErrorCode.
-    inline drogon::HttpStatusCode http_status(ErrorCode code)
+  /// HTTP status codes mapped to each ErrorCode.
+  inline drogon::HttpStatusCode http_status(ErrorCode code)
+  {
+    switch (code)
     {
-        switch (code)
-        {
-        case ErrorCode::bad_request:
-        case ErrorCode::unprocessable_entity:
-            return drogon::k400BadRequest;
-        case ErrorCode::unauthorized:
-            return drogon::k401Unauthorized;
-        case ErrorCode::forbidden:
-        case ErrorCode::policy_denied:
-            return drogon::k403Forbidden;
-        case ErrorCode::not_found:
-        case ErrorCode::resource_not_found:
-            return drogon::k404NotFound;
-        case ErrorCode::conflict:
-        case ErrorCode::resource_already_exists:
-            return drogon::k409Conflict;
-        case ErrorCode::too_many_requests:
-            return drogon::k429TooManyRequests;
-        case ErrorCode::quota_exceeded:
-            return drogon::k422UnprocessableEntity;
-        case ErrorCode::internal_error:
-        default:
-            return drogon::k500InternalServerError;
-        }
+    case ErrorCode::bad_request:
+    case ErrorCode::unprocessable_entity:
+      return drogon::k400BadRequest;
+    case ErrorCode::unauthorized:
+      return drogon::k401Unauthorized;
+    case ErrorCode::forbidden:
+    case ErrorCode::policy_denied:
+      return drogon::k403Forbidden;
+    case ErrorCode::not_found:
+    case ErrorCode::resource_not_found:
+      return drogon::k404NotFound;
+    case ErrorCode::conflict:
+    case ErrorCode::resource_already_exists:
+      return drogon::k409Conflict;
+    case ErrorCode::too_many_requests:
+      return drogon::k429TooManyRequests;
+    case ErrorCode::quota_exceeded:
+      return drogon::k422UnprocessableEntity;
+    case ErrorCode::internal_error:
+    default:
+      return drogon::k500InternalServerError;
     }
+  }
 
-    /// Wrap an Envelope into a Drogon HTTP response with correct status code.
-    drogon::HttpResponsePtr to_response(const Envelope &env,
-                                        drogon::HttpStatusCode status);
+  /// Wrap an Envelope into a Drogon HTTP response with correct status code.
+  drogon::HttpResponsePtr to_response(const Envelope &env,
+                                      drogon::HttpStatusCode status);
 
-    /// Convenience: success 200 response.
-    drogon::HttpResponsePtr respond_ok(Json::Value data,
-                                       const std::string &request_id);
+  /// Convenience: success 200 response.
+  drogon::HttpResponsePtr respond_ok(Json::Value data,
+                                     const std::string &request_id);
 
-    /// Convenience: success 201 created response.
-    drogon::HttpResponsePtr respond_created(Json::Value data,
-                                            const std::string &request_id);
+  /// Convenience: success 201 created response.
+  drogon::HttpResponsePtr respond_created(Json::Value data,
+                                          const std::string &request_id);
 
-    /// Convenience: paginated 200 response.
-    drogon::HttpResponsePtr respond_list(Json::Value data,
-                                         const std::string &request_id,
-                                         std::optional<std::string> next_cursor,
-                                         bool has_more);
+  /// Convenience: paginated 200 response.
+  drogon::HttpResponsePtr respond_list(Json::Value data,
+                                       const std::string &request_id,
+                                       std::optional<std::string> next_cursor,
+                                       bool has_more);
 
-    /// Convenience: error response — status derived from ErrorCode.
-    drogon::HttpResponsePtr respond_error(ErrorCode code,
-                                          const std::string &message,
-                                          const std::string &request_id,
-                                          Json::Value details = {});
+  /// Convenience: error response — status derived from ErrorCode.
+  drogon::HttpResponsePtr respond_error(ErrorCode code,
+                                        const std::string &message,
+                                        const std::string &request_id,
+                                        Json::Value details = {});
 
 } // namespace corvus::api

--- a/include/corvus/api/response.h
+++ b/include/corvus/api/response.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "corvus/api/envelope.h"
+#include <drogon/drogon.h>
+
+namespace corvus::api
+{
+
+    /// HTTP status codes mapped to each ErrorCode.
+    inline drogon::HttpStatusCode http_status(ErrorCode code)
+    {
+        switch (code)
+        {
+        case ErrorCode::bad_request:
+        case ErrorCode::unprocessable_entity:
+            return drogon::k400BadRequest;
+        case ErrorCode::unauthorized:
+            return drogon::k401Unauthorized;
+        case ErrorCode::forbidden:
+        case ErrorCode::policy_denied:
+            return drogon::k403Forbidden;
+        case ErrorCode::not_found:
+        case ErrorCode::resource_not_found:
+            return drogon::k404NotFound;
+        case ErrorCode::conflict:
+        case ErrorCode::resource_already_exists:
+            return drogon::k409Conflict;
+        case ErrorCode::too_many_requests:
+            return drogon::k429TooManyRequests;
+        case ErrorCode::quota_exceeded:
+            return drogon::k422UnprocessableEntity;
+        case ErrorCode::internal_error:
+        default:
+            return drogon::k500InternalServerError;
+        }
+    }
+
+    /// Wrap an Envelope into a Drogon HTTP response with correct status code.
+    drogon::HttpResponsePtr to_response(const Envelope &env,
+                                        drogon::HttpStatusCode status);
+
+    /// Convenience: success 200 response.
+    drogon::HttpResponsePtr respond_ok(Json::Value data,
+                                       const std::string &request_id);
+
+    /// Convenience: success 201 created response.
+    drogon::HttpResponsePtr respond_created(Json::Value data,
+                                            const std::string &request_id);
+
+    /// Convenience: paginated 200 response.
+    drogon::HttpResponsePtr respond_list(Json::Value data,
+                                         const std::string &request_id,
+                                         std::optional<std::string> next_cursor,
+                                         bool has_more);
+
+    /// Convenience: error response — status derived from ErrorCode.
+    drogon::HttpResponsePtr respond_error(ErrorCode code,
+                                          const std::string &message,
+                                          const std::string &request_id,
+                                          Json::Value details = {});
+
+} // namespace corvus::api

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,19 @@
+add_library(corvus-api STATIC
+  api/envelope.cpp
+  api/response.cpp
+  api/request_id.cpp
+)
+
+target_include_directories(corvus-api PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(corvus-api PUBLIC
+  Drogon::Drogon
+)
+
+target_compile_features(corvus-api PUBLIC cxx_std_20)
+
 add_library(corvus-gateway STATIC
   gateway/router.cpp
   gateway/health_handler.cpp
@@ -6,11 +22,12 @@ add_library(corvus-gateway STATIC
 target_include_directories(corvus-gateway PUBLIC
   ${CMAKE_SOURCE_DIR}/include
 )
- 
+
 target_link_libraries(corvus-gateway PUBLIC
+  corvus-api
   Drogon::Drogon
 )
- 
+
 target_compile_features(corvus-gateway PUBLIC cxx_std_20)
 
 add_executable(corvus-core

--- a/src/api/envelope.cpp
+++ b/src/api/envelope.cpp
@@ -1,0 +1,82 @@
+#include "corvus/api/envelope.h"
+#include <chrono>
+#include <ctime>
+#include <sstream>
+#include <iomanip>
+
+namespace corvus::api
+{
+
+    namespace
+    {
+
+        std::string utc_now_iso8601()
+        {
+            const auto now = std::chrono::system_clock::now();
+            const auto time = std::chrono::system_clock::to_time_t(now);
+            std::ostringstream oss;
+            std::tm tm_buf{};
+#ifdef _WIN32
+            gmtime_s(&tm_buf, &time);
+#else
+            gmtime_r(&time, &tm_buf);
+#endif
+            oss << std::put_time(&tm_buf, "%Y-%m-%dT%H:%M:%SZ");
+            return oss.str();
+        }
+
+    } // namespace
+
+    Envelope ok(Json::Value data, const std::string &request_id)
+    {
+        return Envelope{
+            .data = std::move(data),
+            .error = std::nullopt,
+            .meta = Meta{
+                .request_id = request_id,
+                .timestamp = utc_now_iso8601(),
+                .next_cursor = std::nullopt,
+                .has_more = std::nullopt,
+            },
+        };
+    }
+
+    Envelope ok_list(Json::Value data,
+                     const std::string &request_id,
+                     std::optional<std::string> next_cursor,
+                     bool has_more)
+    {
+        return Envelope{
+            .data = std::move(data),
+            .error = std::nullopt,
+            .meta = Meta{
+                .request_id = request_id,
+                .timestamp = utc_now_iso8601(),
+                .next_cursor = std::move(next_cursor),
+                .has_more = has_more,
+            },
+        };
+    }
+
+    Envelope error(ErrorCode code,
+                   const std::string &message,
+                   const std::string &request_id,
+                   Json::Value details)
+    {
+        return Envelope{
+            .data = Json::Value{Json::nullValue},
+            .error = ApiError{
+                .code = code,
+                .message = message,
+                .details = std::move(details),
+            },
+            .meta = Meta{
+                .request_id = request_id,
+                .timestamp = utc_now_iso8601(),
+                .next_cursor = std::nullopt,
+                .has_more = std::nullopt,
+            },
+        };
+    }
+
+} // namespace corvus::api

--- a/src/api/request_id.cpp
+++ b/src/api/request_id.cpp
@@ -1,0 +1,45 @@
+#include "corvus/api/request_id.h"
+#include <random>
+#include <sstream>
+#include <iomanip>
+
+namespace corvus::api {
+
+std::string generate_uuid()
+{
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    std::uniform_int_distribution<uint32_t> dist{0, 0xFFFFFFFF};
+
+    const uint32_t a = dist(rng);
+    const uint32_t b = dist(rng);
+    const uint32_t c = (dist(rng) & 0x0FFF) | 0x4000; // version 4
+    const uint32_t d = (dist(rng) & 0x3FFF) | 0x8000; // variant bits
+    const uint32_t e = dist(rng);
+    const uint32_t f = dist(rng);
+
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0')
+        << std::setw(8) << a << '-'
+        << std::setw(4) << (b >> 16) << '-'
+        << std::setw(4) << c << '-'
+        << std::setw(4) << d << '-'
+        << std::setw(4) << (e >> 16)
+        << std::setw(8) << f;
+    return oss.str();
+}
+
+std::string get_request_id(const drogon::HttpRequestPtr& req)
+{
+    const auto& attrs = req->getAttributes();
+    if (auto val = attrs->get<std::string>(corvus::api::kRequestIdKey);
+        !val.empty()) {
+        return val;
+    }
+    const auto header = req->getHeader("X-Request-ID");
+    if (!header.empty()) {
+        return std::string{header};
+    }
+    return generate_uuid();
+}
+
+} // namespace corvus::api

--- a/src/api/response.cpp
+++ b/src/api/response.cpp
@@ -1,0 +1,47 @@
+#include "corvus/api/response.h"
+
+namespace corvus::api
+{
+    drogon::HttpResponsePtr to_response(const Envelope &env,
+                                        drogon::HttpStatusCode status)
+    {
+        auto resp = drogon::HttpResponse::newHttpJsonResponse(env.to_json());
+        resp->setStatusCode(status);
+        resp->addHeader("Content-Type", "application/json; charset=utf-8");
+        return resp;
+    }
+
+    drogon::HttpResponsePtr respond_ok(Json::Value data,
+                                       const std::string &request_id)
+    {
+        return to_response(ok(std::move(data), request_id), drogon::k200OK);
+    }
+
+    drogon::HttpResponsePtr respond_created(Json::Value data,
+                                            const std::string &request_id)
+    {
+        return to_response(ok(std::move(data), request_id), drogon::k201Created);
+    }
+
+    drogon::HttpResponsePtr respond_list(Json::Value data,
+                                         const std::string &request_id,
+                                         std::optional<std::string> next_cursor,
+                                         bool has_more)
+    {
+        return to_response(
+            ok_list(std::move(data), request_id,
+                    std::move(next_cursor), has_more),
+            drogon::k200OK);
+    }
+
+    drogon::HttpResponsePtr respond_error(ErrorCode code,
+                                          const std::string &message,
+                                          const std::string &request_id,
+                                          Json::Value details)
+    {
+        return to_response(
+            error(code, message, request_id, std::move(details)),
+            http_status(code));
+    }
+
+} // namespace corvus::api

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(corvus-unit-tests
   test_version.cpp
   test_health_handler.cpp
   test_router.cpp
+  test_envelope.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -10,6 +11,7 @@ target_include_directories(corvus-unit-tests PRIVATE
 
 target_link_libraries(corvus-unit-tests PRIVATE
   corvus-gateway
+  corvus-api
   GTest::gtest
   GTest::gtest_main
   GTest::gmock
@@ -25,5 +27,6 @@ gtest_add_tests(
   SOURCES     test_version.cpp
               test_health_handler.cpp
               test_router.cpp
+              test_envelope.cpp
 )
 

--- a/tests/unit/test_envelope.cpp
+++ b/tests/unit/test_envelope.cpp
@@ -1,0 +1,195 @@
+#include <gtest/gtest.h>
+#include "corvus/api/envelope.h"
+
+namespace
+{
+
+    // ok() builder
+
+    TEST(EnvelopeTest, OkHasNullError)
+    {
+        Json::Value data;
+        data["id"] = "123";
+
+        const auto env = corvus::api::ok(data, "req-1");
+        EXPECT_FALSE(env.error.has_value());
+    }
+
+    TEST(EnvelopeTest, OkHasCorrectData)
+    {
+        Json::Value data;
+        data["id"] = "123";
+
+        const auto env = corvus::api::ok(data, "req-1");
+        EXPECT_EQ(env.data["id"].asString(), "123");
+    }
+
+    TEST(EnvelopeTest, OkMetaHasRequestId)
+    {
+        const auto env = corvus::api::ok(Json::Value{}, "my-request-id");
+        EXPECT_EQ(env.meta.request_id, "my-request-id");
+    }
+
+    TEST(EnvelopeTest, OkMetaHasTimestamp)
+    {
+        const auto env = corvus::api::ok(Json::Value{}, "req-1");
+        EXPECT_FALSE(env.meta.timestamp.empty());
+    }
+
+    TEST(EnvelopeTest, OkMetaHasNoPagination)
+    {
+        const auto env = corvus::api::ok(Json::Value{}, "req-1");
+        EXPECT_FALSE(env.meta.next_cursor.has_value());
+        EXPECT_FALSE(env.meta.has_more.has_value());
+    }
+
+    // ok_list() builder
+
+    TEST(EnvelopeTest, OkListHasPaginationCursor)
+    {
+        Json::Value items{Json::arrayValue};
+        const auto env = corvus::api::ok_list(items, "req-1", "cursor-abc", true);
+        ASSERT_TRUE(env.meta.next_cursor.has_value());
+        EXPECT_EQ(env.meta.next_cursor.value(), "cursor-abc");
+    }
+
+    TEST(EnvelopeTest, OkListHasMoreFlag)
+    {
+        Json::Value items{Json::arrayValue};
+        const auto env = corvus::api::ok_list(items, "req-1", "cursor-abc", true);
+        ASSERT_TRUE(env.meta.has_more.has_value());
+        EXPECT_TRUE(env.meta.has_more.value());
+    }
+
+    TEST(EnvelopeTest, OkListWithNoCursorHasNoMore)
+    {
+        Json::Value items{Json::arrayValue};
+        const auto env = corvus::api::ok_list(items, "req-1", std::nullopt, false);
+        ASSERT_TRUE(env.meta.has_more.has_value());
+        EXPECT_FALSE(env.meta.has_more.value());
+    }
+
+    // error() builder
+
+    TEST(EnvelopeTest, ErrorHasNullData)
+    {
+        const auto env = corvus::api::error(
+            corvus::api::ErrorCode::not_found, "not found", "req-1");
+        EXPECT_TRUE(env.data.isNull());
+    }
+
+    TEST(EnvelopeTest, ErrorHasErrorField)
+    {
+        const auto env = corvus::api::error(
+            corvus::api::ErrorCode::not_found, "not found", "req-1");
+        ASSERT_TRUE(env.error.has_value());
+    }
+
+    TEST(EnvelopeTest, ErrorCodeIsCorrect)
+    {
+        const auto env = corvus::api::error(
+            corvus::api::ErrorCode::not_found, "not found", "req-1");
+        EXPECT_EQ(env.error->code, corvus::api::ErrorCode::not_found);
+    }
+
+    TEST(EnvelopeTest, ErrorMessageIsCorrect)
+    {
+        const auto env = corvus::api::error(
+            corvus::api::ErrorCode::bad_request, "invalid input", "req-1");
+        EXPECT_EQ(env.error->message, "invalid input");
+    }
+
+    TEST(EnvelopeTest, ErrorMetaHasRequestId)
+    {
+        const auto env = corvus::api::error(
+            corvus::api::ErrorCode::internal_error, "oops", "req-xyz");
+        EXPECT_EQ(env.meta.request_id, "req-xyz");
+    }
+
+    // to_json() serialization
+
+    TEST(EnvelopeTest, SuccessJsonHasDataField)
+    {
+        Json::Value data;
+        data["key"] = "value";
+        const auto json = corvus::api::ok(data, "req-1").to_json();
+        EXPECT_TRUE(json.isMember("data"));
+        EXPECT_EQ(json["data"]["key"].asString(), "value");
+    }
+
+    TEST(EnvelopeTest, SuccessJsonHasNullErrorField)
+    {
+        const auto json = corvus::api::ok(Json::Value{}, "req-1").to_json();
+        EXPECT_TRUE(json.isMember("error"));
+        EXPECT_TRUE(json["error"].isNull());
+    }
+
+    TEST(EnvelopeTest, SuccessJsonHasMetaField)
+    {
+        const auto json = corvus::api::ok(Json::Value{}, "req-1").to_json();
+        EXPECT_TRUE(json.isMember("meta"));
+        EXPECT_TRUE(json["meta"].isMember("request_id"));
+        EXPECT_TRUE(json["meta"].isMember("timestamp"));
+    }
+
+    TEST(EnvelopeTest, ErrorJsonHasNullDataField)
+    {
+        const auto json = corvus::api::error(
+                              corvus::api::ErrorCode::not_found, "not found", "req-1")
+                              .to_json();
+        EXPECT_TRUE(json["data"].isNull());
+    }
+
+    TEST(EnvelopeTest, ErrorJsonHasErrorObject)
+    {
+        const auto json = corvus::api::error(
+                              corvus::api::ErrorCode::not_found, "Resource not found", "req-1")
+                              .to_json();
+        ASSERT_TRUE(json["error"].isObject());
+        EXPECT_EQ(json["error"]["code"].asString(), "NOT_FOUND");
+        EXPECT_EQ(json["error"]["message"].asString(), "Resource not found");
+    }
+
+    TEST(EnvelopeTest, PaginatedJsonHasCursorInMeta)
+    {
+        Json::Value items{Json::arrayValue};
+        const auto json = corvus::api::ok_list(
+                              items, "req-1", "next-cursor", true)
+                              .to_json();
+        EXPECT_EQ(json["meta"]["next_cursor"].asString(), "next-cursor");
+        EXPECT_TRUE(json["meta"]["has_more"].asBool());
+    }
+
+    // ErrorCode to_string
+
+    TEST(ErrorCodeTest, ToStringNotFound)
+    {
+        EXPECT_EQ(corvus::api::to_string(corvus::api::ErrorCode::not_found),
+                  "NOT_FOUND");
+    }
+
+    TEST(ErrorCodeTest, ToStringBadRequest)
+    {
+        EXPECT_EQ(corvus::api::to_string(corvus::api::ErrorCode::bad_request),
+                  "BAD_REQUEST");
+    }
+
+    TEST(ErrorCodeTest, ToStringInternalError)
+    {
+        EXPECT_EQ(corvus::api::to_string(corvus::api::ErrorCode::internal_error),
+                  "INTERNAL_ERROR");
+    }
+
+    TEST(ErrorCodeTest, ToStringPolicyDenied)
+    {
+        EXPECT_EQ(corvus::api::to_string(corvus::api::ErrorCode::policy_denied),
+                  "POLICY_DENIED");
+    }
+
+    TEST(ErrorCodeTest, ToStringQuotaExceeded)
+    {
+        EXPECT_EQ(corvus::api::to_string(corvus::api::ErrorCode::quota_exceeded),
+                  "QUOTA_EXCEEDED");
+    }
+
+} // namespace


### PR DESCRIPTION
Closes CORV-13

## What
- Envelope struct: always-present data + error + meta fields
- ApiError with machine-readable ErrorCode enum (13 codes)
- Meta with request_id, timestamp, and optional pagination fields
- Builder helpers: ok(), ok_list(), error()
- Response helpers: respond_ok(), respond_created(), respond_list(), respond_error()
- http_status() mapping from ErrorCode to HTTP status code
- UUID v4 generator and request ID extraction
- corvus-api static library wired into CMake build

## Verification
50/50 tests passing