### PR TITLE
feat(CORV-14): add versioned routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ jobs:
           TIMESCALE_PASSWORD: corvus_ci
           GRAFANA_PASSWORD: admin
 
+      - name: Show corvus-core logs
+        run: |
+          sleep 5
+          echo "=== corvus-core logs ==="
+          docker compose logs corvus-core || true
+          echo "=== corvus-core container state ==="
+          docker inspect corvus-corvus-core-1 --format='{{json .State}}' 2>/dev/null || true
+
       - name: Wait for health
         run: bash scripts/wait-for-healthy.sh localhost 8080 30 5
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -73,6 +73,9 @@ LABEL org.opencontainers.image.title="corvus-core" \
 COPY --from=builder /build/libs/              /usr/local/lib/
 COPY --from=builder /build/build/src/corvus-core /usr/local/bin/corvus-core
 
+# /tmp is the only writable directory in distroless
+WORKDIR /tmp
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=3 \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -62,7 +62,7 @@ ARG GIT_SHA
 
 # ── OCI image labels ───────────────────────────────────────────────────────
 LABEL org.opencontainers.image.title="corvus-core" \
-      org.opencontainers.image.description="Corvus management host — C++ core service" \
+      org.opencontainers.image.description="Corvus management host - C++ core service" \
       org.opencontainers.image.version="${CORVUS_VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${GIT_SHA}" \

--- a/include/corvus/gateway/health_handler.h
+++ b/include/corvus/gateway/health_handler.h
@@ -5,8 +5,8 @@
 namespace corvus::gateway
 {
     using HandlerFunc = std::function<void(
-        const drogon::HttpRequestPtr &,
-        std::function<void(const drogon::HttpResponsePtr &)> &&)>;
+                const drogon::HttpRequestPtr&,
+                std::function<void(const drogon::HttpResponsePtr&)>&&)>;
 
     HandlerFunc health_handler();
 

--- a/include/corvus/gateway/not_found_handler.h
+++ b/include/corvus/gateway/not_found_handler.h
@@ -1,14 +1,8 @@
 #pragma once
-#include "corvus/api/envelope.h"
-#include <drogon/drogon.h>
-#include <functional>
+#include "health_handler.h"
 
 namespace corvus::gateway
 {
-
-    using HandlerFunc = std::function<void(
-        const drogon::HttpRequestPtr &,
-        std::function<void(const drogon::HttpResponsePtr &)> &&)>;
 
     HandlerFunc not_found_handler();
 

--- a/include/corvus/gateway/not_found_handler.h
+++ b/include/corvus/gateway/not_found_handler.h
@@ -1,13 +1,15 @@
 #pragma once
+#include "corvus/api/envelope.h"
 #include <drogon/drogon.h>
 #include <functional>
 
 namespace corvus::gateway
 {
+
     using HandlerFunc = std::function<void(
         const drogon::HttpRequestPtr &,
         std::function<void(const drogon::HttpResponsePtr &)> &&)>;
 
-    HandlerFunc health_handler();
+    HandlerFunc not_found_handler();
 
 } // namespace corvus::gateway

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_features(corvus-api PUBLIC cxx_std_20)
 add_library(corvus-gateway STATIC
   gateway/router.cpp
   gateway/health_handler.cpp
+  gateway/not_found_handler.cpp
 )
 
 target_include_directories(corvus-gateway PUBLIC

--- a/src/gateway/not_found_handler.cpp
+++ b/src/gateway/not_found_handler.cpp
@@ -1,24 +1,22 @@
-#include "corvus/gateway/health_handler.h"
+#include "corvus/gateway/not_found_handler.h"
 #include "corvus/api/response.h"
 #include "corvus/api/request_id.h"
-#include "corvus/version.h"
 
 namespace corvus::gateway
 {
 
-    HandlerFunc health_handler()
+    HandlerFunc not_found_handler()
     {
         return [](const drogon::HttpRequestPtr &req,
                   std::function<void(const drogon::HttpResponsePtr &)> &&callback)
         {
             const auto request_id = corvus::api::get_request_id(req);
+            const auto path = req->getPath();
 
-            Json::Value body;
-            body["status"] = "ok";
-            body["version"] = std::string{corvus::version::string()};
-            body["path"] = req->getPath();
-
-            callback(corvus::api::respond_ok(body, request_id));
+            callback(corvus::api::respond_error(
+                corvus::api::ErrorCode::not_found,
+                "The request path '" + path + "' does not exist",
+                request_id));
         };
     }
 

--- a/src/gateway/not_found_handler.cpp
+++ b/src/gateway/not_found_handler.cpp
@@ -11,11 +11,10 @@ namespace corvus::gateway
                   std::function<void(const drogon::HttpResponsePtr &)> &&callback)
         {
             const auto request_id = corvus::api::get_request_id(req);
-            const auto path = req->getPath();
 
             callback(corvus::api::respond_error(
                 corvus::api::ErrorCode::not_found,
-                "The request path '" + path + "' does not exist",
+                "The request path '" + req->getPath() + "' does not exist",
                 request_id));
         };
     }

--- a/src/gateway/router.cpp
+++ b/src/gateway/router.cpp
@@ -1,5 +1,6 @@
 #include "corvus/gateway/router.h"
 #include "corvus/gateway/health_handler.h"
+#include "corvus/gateway/not_found_handler.h"
 #include <drogon/drogon.h>
 
 namespace corvus::gateway
@@ -18,6 +19,19 @@ namespace corvus::gateway
             "/ready",
             handler,
             {drogon::Get});
+
+        // v1 API placeholder
+        // Example:
+        //   drogon::app().registerHandler(
+        //       "/v1/resources", resources_handler(), {drogon::Get, drogon::Post});
+
+        // Catch-all 404
+        // Must be registered last — Drogon matches routes in registration order.
+        drogon::app().registerHandler(
+            "/{catchall}",
+            not_found_handler(),
+            {drogon::Get, drogon::Post, drogon::Put,
+             drogon::Patch, drogon::Delete, drogon::Options});
 
         LOG_INFO << "Routes registered";
     }

--- a/src/gateway/router.cpp
+++ b/src/gateway/router.cpp
@@ -10,26 +10,27 @@ namespace corvus::gateway
     {
         auto handler = health_handler();
 
+        auto h = health_handler();
         drogon::app().registerHandler(
             "/health",
-            handler,
+            [h](const drogon::HttpRequestPtr &req,
+                std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { h(req, std::move(cb)); },
             {drogon::Get});
 
         drogon::app().registerHandler(
             "/ready",
-            handler,
+            [h](const drogon::HttpRequestPtr &req,
+                std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { h(req, std::move(cb)); },
             {drogon::Get});
 
-        // v1 API placeholder
-        // Example:
-        //   drogon::app().registerHandler(
-        //       "/v1/resources", resources_handler(), {drogon::Get, drogon::Post});
-
-        // Catch-all 404
-        // Must be registered last — Drogon matches routes in registration order.
+        auto nf = not_found_handler();
         drogon::app().registerHandler(
             "/{catchall}",
-            not_found_handler(),
+            [nf](const drogon::HttpRequestPtr &req,
+                 std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { nf(req, std::move(cb)); },
             {drogon::Get, drogon::Post, drogon::Put,
              drogon::Patch, drogon::Delete, drogon::Options});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
     corvus::gateway::register_routes();
 
     drogon::app()
-        .setLogPath("./")
+        .setLogPath("")
         .setLogLevel(trantor::Logger::kInfo)
         .addListener("0.0.0.0", 8080)
         .setThreadNum(4)

--- a/tests/unit/test_health_handler.cpp
+++ b/tests/unit/test_health_handler.cpp
@@ -28,13 +28,18 @@ namespace
             result.called = true; });
         return result;
     }
-    Json::Value parse_body(const drogon::HttpResponsePtr &resp)
-    {
 
+    Json::Value parse_envelope(const drogon::HttpResponsePtr &resp)
+    {
         Json::Value root;
         Json::Reader reader;
-        reader.parse(std::string(resp->getBody()), root);
+        reader.parse(std::string{resp->getBody()}, root);
         return root;
+    }
+
+    Json::Value parse_data(const drogon::HttpResponsePtr &resp)
+    {
+        return parse_envelope(resp)["data"];
     }
 
     TEST(HealthHandlerTest, CallbackIsAlwaysInvoked)
@@ -63,38 +68,76 @@ namespace
         EXPECT_EQ(result.response->getStatusCode(), drogon::k200OK);
     }
 
+    // Envelope shape
+
+    TEST(HealthHandlerTest, ResponseHasEnvelopeShape)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto env = parse_envelope(result.response);
+        EXPECT_TRUE(env.isMember("data"));
+        EXPECT_TRUE(env.isMember("error"));
+        EXPECT_TRUE(env.isMember("meta"));
+    }
+
+    TEST(HealthHandlerTest, ResponseErrorFieldIsNull)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto env = parse_envelope(result.response);
+        EXPECT_TRUE(env["error"].isNull());
+    }
+
+    TEST(HealthHandlerTest, ResponseMetaHasRequestId)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto env = parse_envelope(result.response);
+        EXPECT_TRUE(env["meta"].isMember("request_id"));
+        EXPECT_FALSE(env["meta"]["request_id"].asString().empty());
+    }
+
+    TEST(HealthHandlerTest, ResponseMetaHasTimestamp)
+    {
+        const auto result = invoke_handler("/health");
+        ASSERT_TRUE(result.called);
+        const auto env = parse_envelope(result.response);
+        EXPECT_TRUE(env["meta"].isMember("timestamp"));
+        EXPECT_FALSE(env["meta"]["timestamp"].asString().empty());
+    }
+
     TEST(HealthHandlerTest, BodyContainsStatusOk)
     {
         const auto result = invoke_handler("/health");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        ASSERT_TRUE(body.isMember("status"));
-        EXPECT_EQ(body["status"].asString(), "ok");
+        const auto data = parse_data(result.response);
+        ASSERT_TRUE(data.isMember("status"));
+        EXPECT_EQ(data["status"].asString(), "ok");
     }
 
     TEST(HealthHandlerTest, BodyStatusIsOkForReadyEndpoint)
     {
         const auto result = invoke_handler("/ready");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        EXPECT_EQ(body["status"].asString(), "ok");
+        const auto data = parse_data(result.response);
+        EXPECT_EQ(data["status"].asString(), "ok");
     }
 
     TEST(HealthHandlerTest, BodyContainsVersionField)
     {
         const auto result = invoke_handler("/health");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        ASSERT_TRUE(body.isMember("version"));
-        EXPECT_FALSE(body["version"].asString().empty());
+        const auto data = parse_data(result.response);
+        ASSERT_TRUE(data.isMember("version"));
+        EXPECT_FALSE(data["version"].asString().empty());
     }
 
     TEST(HealthHandlerTest, BodyVersionMatchesCurrentVersion)
     {
         const auto result = invoke_handler("/health");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        EXPECT_EQ(body["version"].asString(),
+        const auto data = parse_data(result.response);
+        EXPECT_EQ(data["version"].asString(),
                   std::string{corvus::version::string()});
     }
 
@@ -102,34 +145,34 @@ namespace
     {
         const auto result = invoke_handler("/health");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        ASSERT_TRUE(body.isMember("path"));
+        const auto data = parse_data(result.response);
+        EXPECT_TRUE(data.isMember("path"));
     }
 
     TEST(HealthHandlerTest, BodyPathMatchesRequestPathForHealth)
     {
         const auto result = invoke_handler("/health");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        EXPECT_EQ(body["path"].asString(), "/health");
+        const auto data = parse_data(result.response);
+        EXPECT_EQ(data["path"].asString(), "/health");
     }
 
     TEST(HealthHandlerTest, BodyPathMatchesRequestPathForReady)
     {
         const auto result = invoke_handler("/ready");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        EXPECT_EQ(body["path"].asString(), "/ready");
+        const auto data = parse_data(result.response);
+        EXPECT_EQ(data["path"].asString(), "/ready");
     }
 
     TEST(HealthHandlerTest, BodyContainsAllRequiredFields)
     {
         const auto result = invoke_handler("/health");
         ASSERT_TRUE(result.called);
-        const auto body = parse_body(result.response);
-        EXPECT_TRUE(body.isMember("status"));
-        EXPECT_TRUE(body.isMember("version"));
-        EXPECT_TRUE(body.isMember("path"));
+        const auto data = parse_data(result.response);
+        EXPECT_TRUE(data.isMember("status"));
+        EXPECT_TRUE(data.isMember("version"));
+        EXPECT_TRUE(data.isMember("path"));
     }
 
     TEST(HealthHandlerTest, HandlerCanBeInvokedMultipleTimes)

--- a/tests/unit/test_router.cpp
+++ b/tests/unit/test_router.cpp
@@ -1,7 +1,10 @@
 #include <gtest/gtest.h>
 #include "corvus/gateway/router.h"
 #include "corvus/gateway/health_handler.h"
+#include "corvus/gateway/not_found_handler.h"
+#include "corvus/api/envelope.h"
 #include <drogon/drogon.h>
+#include <json/json.h>
 
 namespace
 {
@@ -12,27 +15,121 @@ namespace
         EXPECT_TRUE(static_cast<bool>(handler));
     }
 
-    TEST(RouterTest, HealthHandlerFactoryReturnsDifferentInstancesEachCall)
-    {
-        auto h1 = corvus::gateway::health_handler();
-        auto h2 = corvus::gateway::health_handler();
-        EXPECT_TRUE(static_cast<bool>(h1));
-        EXPECT_TRUE(static_cast<bool>(h2));
-    }
-
-    TEST(RouterTest, HealthHandlerIsCallableWithValidRequest)
+    TEST(RouterTest, HealthHandlerReturns200)
     {
         auto handler = corvus::gateway::health_handler();
         auto req = drogon::HttpRequest::newHttpRequest();
         req->setPath("/health");
 
-        bool callback_invoked = false;
-        handler(req, [&callback_invoked](const drogon::HttpResponsePtr &resp)
+        bool called = false;
+        handler(req, [&called](const drogon::HttpResponsePtr &resp)
                 {
-                    callback_invoked = true;
-                    EXPECT_NE(resp, nullptr);
-                });
-
-        EXPECT_TRUE(callback_invoked);
+        called = true;
+        EXPECT_EQ(resp->getStatusCode(), drogon::k200OK); });
+        EXPECT_TRUE(called);
     }
-} //namespace
+
+    TEST(RouterTest, HealthHandlerBodyHasEnvelopeShape)
+    {
+        auto handler = corvus::gateway::health_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/health");
+
+        handler(req, [](const drogon::HttpResponsePtr &resp)
+                {
+        Json::Value  root;
+        Json::Reader reader;
+        reader.parse(std::string{resp->getBody()}, root);
+
+        EXPECT_TRUE(root.isMember("data"));
+        EXPECT_TRUE(root.isMember("error"));
+        EXPECT_TRUE(root.isMember("meta"));
+
+        // error must be null on success
+        EXPECT_TRUE(root["error"].isNull());
+
+        // data must have status ok
+        EXPECT_EQ(root["data"]["status"].asString(), "ok");
+
+        // meta must have request_id and timestamp
+        EXPECT_TRUE(root["meta"].isMember("request_id"));
+        EXPECT_TRUE(root["meta"].isMember("timestamp")); });
+    }
+
+    TEST(RouterTest, HealthHandlerBodyHasVersionField)
+    {
+        auto handler = corvus::gateway::health_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/health");
+
+        handler(req, [](const drogon::HttpResponsePtr &resp)
+                {
+        Json::Value  root;
+        Json::Reader reader;
+        reader.parse(std::string{resp->getBody()}, root);
+        EXPECT_FALSE(root["data"]["version"].asString().empty()); });
+    }
+
+    // not_found_handler
+    TEST(RouterTest, NotFoundHandlerReturns404)
+    {
+        auto handler = corvus::gateway::not_found_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/v1/does-not-exist");
+
+        bool called = false;
+        handler(req, [&called](const drogon::HttpResponsePtr &resp)
+                {
+        called = true;
+        EXPECT_EQ(resp->getStatusCode(), drogon::k404NotFound); });
+        EXPECT_TRUE(called);
+    }
+
+    TEST(RouterTest, NotFoundHandlerBodyHasEnvelopeShape)
+    {
+        auto handler = corvus::gateway::not_found_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/unknown");
+
+        handler(req, [](const drogon::HttpResponsePtr &resp)
+                {
+        Json::Value  root;
+        Json::Reader reader;
+        reader.parse(std::string{resp->getBody()}, root);
+
+        EXPECT_TRUE(root.isMember("data"));
+        EXPECT_TRUE(root.isMember("error"));
+        EXPECT_TRUE(root.isMember("meta"));
+        EXPECT_TRUE(root["data"].isNull());
+        EXPECT_FALSE(root["error"].isNull()); });
+    }
+
+    TEST(RouterTest, NotFoundHandlerErrorCodeIsNotFound)
+    {
+        auto handler = corvus::gateway::not_found_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/unknown");
+
+        handler(req, [](const drogon::HttpResponsePtr &resp)
+                {
+        Json::Value  root;
+        Json::Reader reader;
+        reader.parse(std::string{resp->getBody()}, root);
+        EXPECT_EQ(root["error"]["code"].asString(), "NOT_FOUND"); });
+    }
+
+    TEST(RouterTest, NotFoundHandlerMessageContainsPath)
+    {
+        auto handler = corvus::gateway::not_found_handler();
+        auto req = drogon::HttpRequest::newHttpRequest();
+        req->setPath("/v1/missing-resource");
+
+        handler(req, [](const drogon::HttpResponsePtr &resp)
+                {
+            Json::Value  root;
+            Json::Reader reader;
+            reader.parse(std::string{resp->getBody()}, root);
+            const auto msg = root["error"]["message"].asString();
+            EXPECT_NE(msg.find("/v1/missing-resource"), std::string::npos); });
+    }
+} // namespace


### PR DESCRIPTION
Closes CORV-14

## What
- /health and /ready now return standard Envelope response shape
- not_found_handler returns 404 Envelope for all unknown routes
- Catch-all route registered last in router - covers all HTTP methods
- /v1/ placeholder in router with comments for upcoming endpoints
- Updated test_health_handler.cpp to assert envelope shape