### PR TITLE
feat(CORV-15): JWT RS256 middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,12 @@
 POSTGRES_PASSWORD=corvus_dev
 TIMESCALE_PASSWORD=corvus_dev
 GRAFANA_PASSWORD=admin
+
+# JWT RS256 public key for token validation.
+# Generate a keypair once:
+#   openssl genrsa -out corvus_dev.pem 2048
+#   openssl rsa -in corvus_dev.pem -pubout -out corvus_dev_pub.pem
+# Then export for use:
+#   export CORVUS_JWT_PUBLIC_KEY="$(cat corvus_dev_pub.pem)"
+# Or paste the PEM value directly below (keep the newlines):
+CORVUS_JWT_PUBLIC_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,16 @@ jobs:
       - name: Build
         run: cmake --build build --preset ci
 
+      - name: Generate test JWT keypair
+        run: |
+          openssl genrsa -out /tmp/corvus_test.pem 2048
+          openssl rsa -in /tmp/corvus_test.pem -pubout -out /tmp/corvus_test_pub.pem
+
       - name: Run unit tests
         run: ctest --test-dir build --output-on-failure
+        env:
+          CORVUS_TEST_PRIVATE_KEY: ${{ env.CORVUS_TEST_PRIVATE_KEY }}
+          CORVUS_TEST_PUBLIC_KEY: ${{ env.CORVUS_TEST_PUBLIC_KEY }}
 
   python-test:
     name: Python lint and unit tests
@@ -102,12 +110,27 @@ jobs:
       - name: Install Python test deps
         run: pip install pytest httpx
 
+      - name: Generate test JWT keypair
+        run: |
+          openssl genrsa -out /tmp/corvus_test.pem 2048
+          openssl rsa -in /tmp/corvus_test.pem -pubout -out /tmp/corvus_test_pub.pem
+          echo "CORVUS_TEST_PRIVATE_KEY<<EOF_KEY" >> $GITHUB_ENV
+          cat /tmp/corvus_test.pem >> $GITHUB_ENV
+          echo "EOF_KEY" >> $GITHUB_ENV
+          echo "CORVUS_TEST_PUBLIC_KEY<<EOF_KEY" >> $GITHUB_ENV
+          cat /tmp/corvus_test_pub.pem >> $GITHUB_ENV
+          echo "EOF_KEY" >> $GITHUB_ENV
+          echo "CORVUS_JWT_PUBLIC_KEY<<EOF_KEY" >> $GITHUB_ENV
+          cat /tmp/corvus_test_pub.pem >> $GITHUB_ENV
+          echo "EOF_KEY" >> $GITHUB_ENV
+
       - name: Start stack
         run: docker compose up -d --build
         env:
           POSTGRES_PASSWORD: corvus_ci
           TIMESCALE_PASSWORD: corvus_ci
           GRAFANA_PASSWORD: admin
+          CORVUS_JWT_PUBLIC_KEY: ${{ env.CORVUS_JWT_PUBLIC_KEY }}
 
       - name: Show corvus-core logs
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,19 @@
-
-# ── Networks ───────────────────────────────────────────────────────────────
+# Networks
 networks:
   frontend:
   backend:
   datastore:
   observability:
 
-    # ── Volumes ────────────────────────────────────────────────────────────────
+# Volumes
 volumes:
   postgres_data:
   redis_data:
-  timescale_data:
   prometheus_data:
   grafana_data:
   loki_data:
 
-# ── Default resource limits (override per service if needed) ───────────────
+# Default resource limits (override per service if needed)
 x-default-resources: &default-resources
   limits:
     memory: 256m
@@ -24,7 +22,7 @@ x-default-resources: &default-resources
     memory: 64m
 
 services:
-  # ── C++ management core ─────────────────────────────────────────────────
+  # C++ management core
   corvus-core:
     build:
       context: .
@@ -35,6 +33,7 @@ services:
       - CORVUS_ENV=development
       - CORVUS_DB_HOST=postgres
       - CORVUS_REDIS_HOST=redis
+      - CORVUS_JWT_PUBLIC_KEY=${CORVUS_JWT_PUBLIC_KEY}
     depends_on:
       postgres:
         condition: service_healthy
@@ -52,7 +51,7 @@ services:
         reservations:
           memory: 32m
 
-  # ── PostgreSQL ──────────────────────────────────────────────────────────
+  # PostgreSQL - alpine image, minimal config
   postgres:
     image: postgres:16-alpine
     environment:
@@ -70,7 +69,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U corvus"]
+      test: ["CMD-SHELL", "pg_isready -U corvus -d corvus"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -85,7 +84,7 @@ services:
         reservations:
           memory: 32m
 
-  # ── Redis ────────────────────────────────────────────────────────────────
+  # Redis - alpine, AOF disabled for dev (faster, less disk)
   redis:
     image: redis:7-alpine
     command: >
@@ -112,7 +111,7 @@ services:
         reservations:
           memory: 32m
 
-  # ── TimescaleDB ──────────────────────────────────────────────────────────
+  # TimescaleDB - replaced with postgres + timescaledb extension
   timescaledb:
     image: postgres:16-alpine
     environment:
@@ -142,7 +141,7 @@ services:
         reservations:
           memory: 32m
 
-  # ── Prometheus ───────────────────────────────────────────────────────────
+  # Prometheus - short retention, no remote write
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -169,7 +168,7 @@ services:
         reservations:
           memory: 64m
 
-  # ── Grafana ──────────────────────────────────────────────────────────────
+  # Grafana - OSS image, minimal plugins
   grafana:
     image: grafana/grafana-oss:latest
     environment:
@@ -198,7 +197,7 @@ services:
         reservations:
           memory: 64m
 
-  # ── Loki ─────────────────────────────────────────────────────────────────
+  #  Loki - filesystem storage, minimal config
   loki:
     image: grafana/loki:latest
     volumes:
@@ -218,7 +217,7 @@ services:
         reservations:
           memory: 32m
 
-  # ── Jaeger ───────────────────────────────────────────────────────────────
+  # Jaeger memory storage only, no persistence needed for dev
   jaeger:
     image: jaegertracing/jaeger:latest
     environment:

--- a/include/corvus/auth/jwt_validator.h
+++ b/include/corvus/auth/jwt_validator.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <string>
+#include <optional>
+#include <stdexcept>
+
+namespace corvus::auth
+{
+
+    /// Thrown at startup if CORVUS_JWT_PUBLIC_KEY is missing or unparseable
+    struct JwtConfigError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    /// Thrown when a token fails validation (missing, expired, wrong alg, etc.)
+    struct JwtValidationError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    /// Holds the validated claims extracted from a token
+    struct Claims
+    {
+        std::string subject;
+        std::string issuer;
+    };
+
+    /// Loads an RS256 public key from the environment and validates JWT Bearer tokens
+    /// Construct once at startup; share across threads (immutable after construction)
+
+    class JwtValidator
+    {
+    public:
+        /// Reads CORVUS_JWT_PUBLIC_KEY from the environment
+        /// Throws JwtConfigError if the variable is absent or the PEM is invalid
+        JwtValidator();
+
+        /// Exposed for testing - pass the PEM directly
+        explicit JwtValidator(const std::string &public_key_pem);
+
+        /// Validate a raw token string (without "Bearer " prefix)
+        /// Returns Claims on success; throws JwtValidationError on any failure
+        Claims validate(const std::string &token) const;
+
+    private:
+        std::string public_key_pem_;
+    };
+} // namespace corvus::auth

--- a/include/corvus/auth/middleware.h
+++ b/include/corvus/auth/middleware.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "corvus/auth/jwt_validator.h"
+#include <drogon/drogon.h>
+#include <memory>
+
+namespace corvus::auth
+{
+    /// Drogon pre-handler that enforces JWT authentication on /v1/* routes
+    void register_jwt_middleware(std::shared_ptr<JwtValidator> validator);
+} // namespace corvus::auth

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,12 +31,32 @@ target_link_libraries(corvus-gateway PUBLIC
 
 target_compile_features(corvus-gateway PUBLIC cxx_std_20)
 
+find_package(jwt-cpp CONFIG REQUIRED)
+
+add_library(corvus-auth STATIC
+  auth/jwt_validator.cpp
+  auth/middleware.cpp
+)
+
+target_include_directories(corvus-auth PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(corvus-auth PUBLIC
+  corvus-api
+  Drogon::Drogon  
+  jwt-cpp::jwt-cpp
+)
+
+target_compile_features(corvus-auth PUBLIC cxx_std_20)
+
 add_executable(corvus-core
   main.cpp
 )
 
 target_link_libraries(corvus-core PRIVATE
   corvus-gateway
+  corvus-auth
 )
 
 target_compile_features(corvus-core PRIVATE cxx_std_20)

--- a/src/auth/jwt_validator.cpp
+++ b/src/auth/jwt_validator.cpp
@@ -1,0 +1,73 @@
+#include "corvus/auth/jwt_validator.h"
+#include <jwt-cpp/jwt.h>
+#include <jwt-cpp/traits/nlohmann-json/defaults.h>
+#include <cstdlib>
+
+using jwt_traits = jwt::traits::nlohmann_json;
+
+namespace corvus::auth
+{
+
+    static void verify_pem(const std::string &pem)
+    {
+        try
+        {
+            jwt::algorithm::rs256 algo{pem};
+            (void)algo;
+        }
+        catch (const std::exception &e)
+        {
+            throw JwtConfigError(std::string("Invalid RS256 public key PEM: ") + e.what());
+        }
+    }
+    JwtValidator::JwtValidator()
+    {
+        const char *raw = std::getenv("CORVUS_JWT_PUBLIC_KEY");
+        if (!raw || std::string(raw).empty())
+        {
+            throw JwtConfigError(
+                "CORVUS_JWT_PUBLIC_KEY is not set. "
+                "Refusing to start without a JWT public key.");
+        }
+
+        verify_pem(raw);
+        public_key_pem_ = raw;
+    }
+
+    JwtValidator::JwtValidator(const std::string &public_key_pem)
+    {
+        verify_pem(public_key_pem);
+        public_key_pem_ = public_key_pem;
+    }
+
+    Claims JwtValidator::validate(const std::string &token) const
+    {
+        try
+        {
+            auto decoded = jwt::decode<jwt_traits>(token);
+            jwt::verify<jwt_traits>(jwt::default_clock{})
+                .allow_algorithm(jwt::algorithm::rs256{public_key_pem_})
+                .with_type("JWT")
+                .verify(decoded);
+
+            Claims claims;
+            if (decoded.has_subject())
+            {
+                claims.subject = decoded.get_subject();
+            }
+            if (decoded.has_issuer())
+            {
+                claims.issuer = decoded.get_issuer();
+            }
+            return claims;
+        }
+        catch (const jwt::error::token_verification_exception &e)
+        {
+            throw JwtValidationError(e.what());
+        }
+        catch (const std::exception &e)
+        {
+            throw JwtValidationError(std::string("Token decode failed: ") + e.what());
+        }
+    }
+} // namespace corvus::auth

--- a/src/auth/middleware.cpp
+++ b/src/auth/middleware.cpp
@@ -1,0 +1,50 @@
+#include "corvus/auth/middleware.h"
+#include "corvus/api/response.h"
+#include "corvus/api/request_id.h"
+#include <drogon/drogon.h>
+
+namespace corvus::auth
+{
+    void register_jwt_middleware(std::shared_ptr<JwtValidator> validator)
+    {
+        drogon::app().registerPreHandlingAdvice(
+            [validator](const drogon::HttpRequestPtr &req, drogon::AdviceCallback &&cb, drogon::AdviceChainCallback &&next)
+            {
+                // Only apply to /v1/* routes
+                const std::string &path = req->getPath();
+                if (path.rfind("/v1/", 0) != 0)
+                {
+                    next();
+                    return;
+                }
+
+                // Extract Bearer token
+                const std::string auth_header = req->getHeader("Authorization");
+                const std::string prefix = "Bearer ";
+                if (auth_header.empty() || auth_header.rfind(prefix, 0) != 0)
+                {
+                    const auto request_id = corvus::api::get_request_id(req);
+                    cb(corvus::api::respond_error(
+                        corvus::api::ErrorCode::unauthorized,
+                        "Missing or malformed Authorization header",
+                        request_id));
+                    return;
+                }
+
+                const std::string token = auth_header.substr(prefix.size());
+                try
+                {
+                    validator->validate(token);
+                    next(); // Token valid, proceed to the next handler
+                }
+                catch (const JwtValidationError &e)
+                {
+                    const auto request_id = corvus::api::get_request_id(req);
+                    cb(corvus::api::respond_error(
+                        corvus::api::ErrorCode::unauthorized,
+                        std::string("Invalid token: ") + e.what(),
+                        request_id));
+                }
+            });
+    }
+} // namespace corvus::auth

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,11 @@
 #include <drogon/drogon.h>
 #include "corvus/gateway/router.h"
+#include "corvus/auth/middleware.h"
+#include "corvus/auth/jwt_validator.h"
 #include "corvus/version.h"
 #include <cstring>
 #include <iostream>
+#include <memory>
 
 int main(int argc, char *argv[])
 {
@@ -12,10 +15,26 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    std::shared_ptr<corvus::auth::JwtValidator> validator;
+    try
+    {
+        validator = std::make_shared<corvus::auth::JwtValidator>();
+    }
+    catch (const corvus::auth::JwtConfigError &e)
+    {
+        std::cerr << "FATAL: " << e.what() << "\n";
+        return 1;
+    }
+
+    // Register auth middleware (runs before route handlers)
+    corvus::auth::register_jwt_middleware(validator);
+
     LOG_INFO << "Corvus " << corvus::version::string() << " starting";
 
+    // Register routes
     corvus::gateway::register_routes();
 
+    // Configure and run Drogon
     drogon::app()
         .setLogPath("")
         .setLogLevel(trantor::Logger::kInfo)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(corvus-unit-tests
   test_health_handler.cpp
   test_router.cpp
   test_envelope.cpp
+  test_jwt_validator.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -12,6 +13,7 @@ target_include_directories(corvus-unit-tests PRIVATE
 target_link_libraries(corvus-unit-tests PRIVATE
   corvus-gateway
   corvus-api
+  corvus-auth
   GTest::gtest
   GTest::gtest_main
   GTest::gmock
@@ -28,5 +30,6 @@ gtest_add_tests(
               test_health_handler.cpp
               test_router.cpp
               test_envelope.cpp
+              test_jwt_validator.cpp
 )
 

--- a/tests/unit/test_jwt_validator.cpp
+++ b/tests/unit/test_jwt_validator.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+#include "corvus/auth/jwt_validator.h"
+#include <jwt-cpp/jwt.h>
+#include <jwt-cpp/traits/nlohmann-json/defaults.h>
+
+using jwt_traits = jwt::traits::nlohmann_json;
+#include <cstdlib>
+
+// Keys are provided via environment variables:
+//   CORVUS_TEST_PRIVATE_KEY - RSA private key PEM (for minting test tokens)
+//   CORVUS_TEST_PUBLIC_KEY  - RSA public key PEM  (passed to JwtValidator)
+//
+// Generate once:
+//   openssl genrsa -out /tmp/corvus_test.pem 2048
+//   openssl rsa -in /tmp/corvus_test.pem -pubout -out /tmp/corvus_test_pub.pem
+//   export CORVUS_TEST_PRIVATE_KEY="$(cat /tmp/corvus_test.pem)"
+//   export CORVUS_TEST_PUBLIC_KEY="$(cat /tmp/corvus_test_pub.pem)"
+
+static std::string get_env_or_skip(const char *var)
+{
+    const char *val = std::getenv(var);
+    if (!val || std::string(val).empty())
+    {
+        return "";
+    }
+    return val;
+}
+
+class JwtValidatorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        private_key_ = get_env_or_skip("CORVUS_TEST_PRIVATE_KEY");
+        public_key_ = get_env_or_skip("CORVUS_TEST_PUBLIC_KEY");
+
+        if (private_key_.empty() || public_key_.empty())
+        {
+            GTEST_SKIP() << "Set CORVUS_TEST_PRIVATE_KEY and CORVUS_TEST_PUBLIC_KEY "
+                            "to run JWT tests. See tests/unit/test_jwt_validator.cpp.";
+        }
+    }
+
+    std::string make_token(const std::string &subject = "test-user",
+                           int expires_in_seconds = 3600) const
+    {
+        auto now = std::chrono::system_clock::now();
+        return jwt::create<jwt_traits>()
+            .set_type("JWT")
+            .set_issuer("corvus-test")
+            .set_subject(subject)
+            .set_issued_at(now)
+            .set_expires_at(now + std::chrono::seconds(expires_in_seconds))
+            .sign(jwt::algorithm::rs256{public_key_, private_key_});
+    }
+
+    std::string private_key_;
+    std::string public_key_;
+};
+
+TEST_F(JwtValidatorTest, ThrowsOnEmptyPem)
+{
+    EXPECT_THROW(corvus::auth::JwtValidator(""), corvus::auth::JwtConfigError);
+}
+
+TEST_F(JwtValidatorTest, ThrowsOnInvalidPem)
+{
+    EXPECT_THROW(corvus::auth::JwtValidator("not-a-pem"),
+                 corvus::auth::JwtConfigError);
+}
+
+TEST_F(JwtValidatorTest, ConstructsWithValidPem)
+{
+    EXPECT_NO_THROW({ auto v = corvus::auth::JwtValidator(public_key_); (void)v; });
+}
+
+TEST_F(JwtValidatorTest, AcceptsValidToken)
+{
+    corvus::auth::JwtValidator v{public_key_};
+    auto claims = v.validate(make_token("alice"));
+    EXPECT_EQ(claims.subject, "alice");
+    EXPECT_EQ(claims.issuer, "corvus-test");
+}
+
+TEST_F(JwtValidatorTest, RejectsExpiredToken)
+{
+    corvus::auth::JwtValidator v{public_key_};
+    EXPECT_THROW(v.validate(make_token("alice", -1)),
+                 corvus::auth::JwtValidationError);
+}
+
+TEST_F(JwtValidatorTest, RejectsMalformedToken)
+{
+    corvus::auth::JwtValidator v{public_key_};
+    EXPECT_THROW(v.validate("not.a.jwt"), corvus::auth::JwtValidationError);
+}
+
+TEST_F(JwtValidatorTest, RejectsEmptyToken)
+{
+    corvus::auth::JwtValidator v{public_key_};
+    EXPECT_THROW(v.validate(""), corvus::auth::JwtValidationError);
+}
+
+TEST_F(JwtValidatorTest, RejectsWrongAlgorithm)
+{
+    corvus::auth::JwtValidator v{public_key_};
+    auto hs_token = jwt::create<jwt_traits>()
+                        .set_type("JWT")
+                        .set_subject("attacker")
+                        .set_expires_at(std::chrono::system_clock::now() + std::chrono::hours(1))
+                        .sign(jwt::algorithm::hs256{"supersecret"});
+    EXPECT_THROW(v.validate(hs_token), corvus::auth::JwtValidationError);
+}
+
+TEST(JwtValidatorEnvTest, ThrowsWhenEnvVarMissing)
+{
+    unsetenv("CORVUS_JWT_PUBLIC_KEY");
+    EXPECT_THROW(corvus::auth::JwtValidator(), corvus::auth::JwtConfigError);
+}
+
+TEST(JwtValidatorEnvTest, LoadsKeyFromEnvVar)
+{
+    const char *pub = std::getenv("CORVUS_TEST_PUBLIC_KEY");
+    if (!pub || std::string(pub).empty())
+    {
+        GTEST_SKIP() << "CORVUS_TEST_PUBLIC_KEY not set";
+    }
+    setenv("CORVUS_JWT_PUBLIC_KEY", pub, 1);
+    EXPECT_NO_THROW(corvus::auth::JwtValidator());
+    unsetenv("CORVUS_JWT_PUBLIC_KEY");
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,5 +2,5 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "corvus",
   "version": "0.1.0",
-  "dependencies": ["drogon", "gtest"]
+  "dependencies": ["drogon", "gtest", "jwt-cpp", "nlohmann-json"]
 }


### PR DESCRIPTION
Closes CORV-15

Added JWT RS256 authentication middleware that protects all /v1/* routes.

- JwtValidator loads RS256 public key from CORVUS_JWT_PUBLIC_KEY env var at startup
- Drogon pre-handling advice intercepts requests to /v1/*, extracts Bearer token, returns 401 Envelope on missing/expired/invalid/wrong-algorithm tokens
- /health and /ready remain unauthenticated
- corvus-auth static library added to CMake; jwt-cpp + nlohmann-json added to vcpkg
- CI generates an ephemeral RSA keypair per run; keys never touch source control
- 6 unit tests covering construction, validation, and env var loading