### PR TITLE
feat(CORV-16): API key middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ GRAFANA_PASSWORD=admin
 #   export CORVUS_JWT_PUBLIC_KEY="$(cat corvus_dev_pub.pem)"
 # Or paste the PEM value directly below (keep the newlines):
 CORVUS_JWT_PUBLIC_KEY=
+
+# Redis connection for API key validation (defaults shown)
+CORVUS_REDIS_HOST=localhost
+CORVUS_REDIS_PORT=6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,9 @@ services:
     environment:
       - CORVUS_ENV=development
       - CORVUS_DB_HOST=postgres
-      - CORVUS_REDIS_HOST=redis
       - CORVUS_JWT_PUBLIC_KEY=${CORVUS_JWT_PUBLIC_KEY}
+      - CORVUS_REDIS_HOST=redis
+      - CORVUS_REDIS_PORT=6379
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,9 @@ services:
     environment:
       - CORVUS_ENV=development
       - CORVUS_DB_HOST=postgres
-      - CORVUS_JWT_PUBLIC_KEY=${CORVUS_JWT_PUBLIC_KEY}
       - CORVUS_REDIS_HOST=redis
       - CORVUS_REDIS_PORT=6379
+      - CORVUS_JWT_PUBLIC_KEY=${CORVUS_JWT_PUBLIC_KEY}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     networks:
       - frontend
       - backend
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -76,7 +76,7 @@ services:
       retries: 5
     networks:
       - datastore
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -103,7 +103,7 @@ services:
       retries: 5
     networks:
       - datastore
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -133,7 +133,7 @@ services:
       retries: 5
     networks:
       - datastore
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -160,7 +160,7 @@ services:
     networks:
       - observability
       - backend
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -189,7 +189,7 @@ services:
       - prometheus
     networks:
       - observability
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -209,7 +209,7 @@ services:
       - "3100:3100"
     networks:
       - observability
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:
@@ -232,7 +232,7 @@ services:
     networks:
       - observability
       - backend
-    restart: unless-stopped
+    restart: on-failure
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     networks:
       - frontend
       - backend
+      - datastore
     restart: on-failure
     deploy:
       resources:

--- a/include/corvus/auth/api_key_middleware.h
+++ b/include/corvus/auth/api_key_middleware.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "corvus/auth/api_key_validator.h"
+#include <memory>
+
+namespace corvus::auth
+{
+    /// Runs after JWT middleware
+    /// Registers a Drogon pre-handling advice that enforces X-Api-Key on /v1/* routes
+    void register_api_key_middleware(std::shared_ptr<ApiKeyValidator> validator);
+} // namespace corvus::auth

--- a/include/corvus/auth/api_key_validator.h
+++ b/include/corvus/auth/api_key_validator.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <string>
+#include <stdexcept>
+#include <memory>
+
+struct redisContext;
+
+namespace corvus::auth
+{
+
+    struct ApiKeyConfigError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    struct ApiKeyValidationError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    struct ApiKeyInfo
+    {
+        std::string client_id;
+        std::string scopes;
+    };
+
+    /// Connects to Redis at startup and validates API keys on each request
+    /// Thread-safe: each call opens its own connection
+
+    class ApiKeyValidator
+    {
+    public:
+        ApiKeyValidator();
+
+        /// Exposed for testing
+        ApiKeyValidator(const std::string &host, int port);
+
+        ~ApiKeyValidator();
+
+        /// Look up a raw API key. Returns ApiKeyInfo on success.
+        ApiKeyInfo validate(const std::string &raw_key) const;
+
+        /// SHA-256 hash a raw key
+        static std::string hash_key(const std::string &raw_key);
+
+    private:
+        std::string host_;
+        int port_;
+
+        redisContext *connect() const;
+    };
+
+} // namespace corus::auth

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,10 +32,14 @@ target_link_libraries(corvus-gateway PUBLIC
 target_compile_features(corvus-gateway PUBLIC cxx_std_20)
 
 find_package(jwt-cpp CONFIG REQUIRED)
+find_package(hiredis CONFIG REQUIRED)
+find_package(OpenSSL REQUIRED)
 
 add_library(corvus-auth STATIC
   auth/jwt_validator.cpp
   auth/middleware.cpp
+  auth/api_key_validator.cpp
+  auth/api_key_middleware.cpp
 )
 
 target_include_directories(corvus-auth PUBLIC
@@ -46,6 +50,8 @@ target_link_libraries(corvus-auth PUBLIC
   corvus-api
   Drogon::Drogon  
   jwt-cpp::jwt-cpp
+  hiredis::hiredis
+  OpenSSL::Crypto
 )
 
 target_compile_features(corvus-auth PUBLIC cxx_std_20)

--- a/src/auth/api_key_middleware.cpp
+++ b/src/auth/api_key_middleware.cpp
@@ -1,0 +1,48 @@
+#include "corvus/auth/api_key_middleware.h"
+#include "corvus/api/response.h"
+#include "corvus/api/request_id.h"
+#include <drogon/drogon.h>
+
+namespace corvus::auth
+{
+    void register_api_key_middleware(std::shared_ptr<ApiKeyValidator> validator)
+    {
+        drogon::app().registerPreHandlingAdvice(
+            [validator](const drogon::HttpRequestPtr &req,
+                        drogon::AdviceCallback &&cb,
+                        drogon::AdviceChainCallback &&next)
+            {
+                // Only enforces on /v1/*
+                if (req->getPath().rfind("/v1/", 0) != 0)
+                {
+                    next();
+                    return;
+                }
+
+                const std::string raw_key = req->getHeader("X-Api-Key");
+                if (raw_key.empty())
+                {
+                    const auto request_id = corvus::api::get_request_id(req);
+                    cb(corvus::api::respond_error(
+                        corvus::api::ErrorCode::unauthorized,
+                        "Missing X-Api-Key header",
+                        request_id));
+                    return;
+                }
+
+                try
+                {
+                    validator->validate(raw_key);
+                    next();
+                }
+                catch (const ApiKeyValidationError &e)
+                {
+                    const auto request_id = corvus::api::get_request_id(req);
+                    cb(corvus::api::respond_error(
+                        corvus::api::ErrorCode::unauthorized,
+                        std::string("Invalid API key: ") + e.what(),
+                        request_id));
+                }
+            });
+    }
+} // namespace corvus::auth

--- a/src/auth/api_key_validator.cpp
+++ b/src/auth/api_key_validator.cpp
@@ -46,7 +46,7 @@ namespace corvus::auth
         // Retry up to 5 times with 1s backoff — Docker DNS may not resolve
         // immediately even after the Redis healthcheck passes
         std::string last_error;
-        for (int attempt = 1; attempt <= 5; ++attempt)
+        for (int attempt = 1; attempt <= 10; ++attempt)
         {
             try
             {

--- a/src/auth/api_key_validator.cpp
+++ b/src/auth/api_key_validator.cpp
@@ -1,12 +1,11 @@
 #include "corvus/auth/api_key_validator.h"
 #include <hiredis/hiredis.h>
-#include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <cstdlib>
-#include <cstring>
 #include <sstream>
 #include <iomanip>
-#include <stdexcept>
+#include <thread>
+#include <chrono>
 
 namespace corvus::auth
 {
@@ -44,8 +43,27 @@ namespace corvus::auth
         host_ = (host && *host) ? host : "localhost";
         port_ = (port && *port) ? std::stoi(port) : 6379;
 
-        redisContext *c = connect();
-        redisFree(c);
+        // Retry up to 5 times with 1s backoff — Docker DNS may not resolve
+        // immediately even after the Redis healthcheck passes
+        std::string last_error;
+        for (int attempt = 1; attempt <= 5; ++attempt)
+        {
+            try
+            {
+                redisContext *c = connect();
+                redisFree(c);
+                return; // Connected successfully
+            }
+            catch (const ApiKeyConfigError &e)
+            {
+                last_error = e.what();
+                if (attempt < 5)
+                {
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                }
+            }
+        }
+        throw ApiKeyConfigError("Redis unreachable after 5 attempts: " + last_error);
     }
 
     ApiKeyValidator::ApiKeyValidator(const std::string &host, int port)
@@ -59,7 +77,7 @@ namespace corvus::auth
 
     redisContext *ApiKeyValidator::connect() const
     {
-        struct timeval timeout = {1, 500000}; // 1.5 seconds
+        struct timeval timeout = {3, 0}; // 3 seconds
         redisContext *c = redisConnectWithTimeout(host_.c_str(), port_, timeout);
 
         if (!c || c->err)

--- a/src/auth/api_key_validator.cpp
+++ b/src/auth/api_key_validator.cpp
@@ -1,0 +1,137 @@
+#include "corvus/auth/api_key_validator.h"
+#include <hiredis/hiredis.h>
+#include <openssl/sha.h>
+#include <openssl/evp.h>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+#include <iomanip>
+#include <stdexcept>
+
+namespace corvus::auth
+{
+
+    std::string ApiKeyValidator::hash_key(const std::string &raw_key)
+    {
+        unsigned char hash[EVP_MAX_MD_SIZE];
+        unsigned int hash_len = 0;
+
+        EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr);
+        EVP_DigestUpdate(ctx, raw_key.data(), raw_key.size());
+        EVP_DigestFinal_ex(ctx, hash, &hash_len);
+        EVP_MD_CTX_free(ctx);
+
+        std::ostringstream hex;
+        for (unsigned int i = 0; i < hash_len; ++i)
+        {
+            hex << std::hex << std::setw(2) << std::setfill('0')
+                << static_cast<int>(hash[i]);
+        }
+        return hex.str();
+    }
+
+    static std::string redis_key(const std::string &hash)
+    {
+        return "corvus:apikeys:" + hash;
+    }
+
+    ApiKeyValidator::ApiKeyValidator()
+    {
+        const char *host = std::getenv("CORVUS_REDIS_HOST");
+        const char *port = std::getenv("CORVUS_REDIS_PORT");
+
+        host_ = (host && *host) ? host : "localhost";
+        port_ = (port && *port) ? std::stoi(port) : 6379;
+
+        redisContext *c = connect();
+        redisFree(c);
+    }
+
+    ApiKeyValidator::ApiKeyValidator(const std::string &host, int port)
+        : host_(host), port_(port)
+    {
+        redisContext *c = connect();
+        redisFree(c);
+    }
+
+    ApiKeyValidator::~ApiKeyValidator() = default;
+
+    redisContext *ApiKeyValidator::connect() const
+    {
+        struct timeval timeout = {1, 500000}; // 1.5 seconds
+        redisContext *c = redisConnectWithTimeout(host_.c_str(), port_, timeout);
+
+        if (!c || c->err)
+        {
+            std::string msg = "Redis connection failed";
+            if (c)
+            {
+                msg += ": ";
+                msg += c->errstr;
+                redisFree(c);
+            }
+            throw ApiKeyConfigError(msg);
+        }
+        return c;
+    }
+
+    ApiKeyInfo ApiKeyValidator::validate(const std::string &raw_key) const
+    {
+        if (raw_key.empty())
+        {
+            throw ApiKeyValidationError("API key must not be empty");
+        }
+
+        const std::string hashed = hash_key(raw_key);
+        const std::string rkey = redis_key(hashed);
+
+        redisContext *c = nullptr;
+        try
+        {
+            c = connect();
+        }
+        catch (const ApiKeyConfigError &e)
+        {
+            throw ApiKeyValidationError(
+                std::string("Redis unavailable, cannot validate API key: ") + e.what());
+        }
+
+        // HGETALL corvus:apikeys:<hash>
+        auto *reply = static_cast<redisReply *>(
+            redisCommand(c, "HGETALL %s", rkey.c_str()));
+        redisFree(c);
+
+        if (!reply)
+        {
+            throw ApiKeyValidationError("Redis returned null reply");
+        }
+
+        // HGETALL returns flat array: [field, value, field, value, ...]
+        if (reply->type != REDIS_REPLY_ARRAY || reply->elements == 0)
+        {
+            freeReplyObject(reply);
+            throw ApiKeyValidationError("Unknown or revoked API key");
+        }
+
+        ApiKeyInfo info;
+        for (size_t i = 0; i + 1 < reply->elements; i += 2)
+        {
+            std::string field = reply->element[i]->str;
+            std::string value = reply->element[i + 1]->str;
+            if (field == "client_id")
+                info.client_id = value;
+            else if (field == "scopes")
+                info.scopes = value;
+        }
+        freeReplyObject(reply);
+
+        if (info.client_id.empty())
+        {
+            throw ApiKeyValidationError("API key record missing client_id");
+        }
+
+        return info;
+    }
+
+} // namespace corvus::auth

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 #include "corvus/gateway/router.h"
 #include "corvus/auth/middleware.h"
 #include "corvus/auth/jwt_validator.h"
+#include "corvus/auth/api_key_middleware.h"
+#include "corvus/auth/api_key_validator.h"
 #include "corvus/version.h"
 #include <cstring>
 #include <iostream>
@@ -15,10 +17,10 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    std::shared_ptr<corvus::auth::JwtValidator> validator;
+    std::shared_ptr<corvus::auth::JwtValidator> jwt_validator;
     try
     {
-        validator = std::make_shared<corvus::auth::JwtValidator>();
+        jwt_validator = std::make_shared<corvus::auth::JwtValidator>();
     }
     catch (const corvus::auth::JwtConfigError &e)
     {
@@ -26,8 +28,20 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    std::shared_ptr<corvus::auth::ApiKeyValidator> api_key_validator;
+    try
+    {
+        api_key_validator = std::make_shared<corvus::auth::ApiKeyValidator>();
+    }
+    catch (const corvus::auth::ApiKeyConfigError &e)
+    {
+        std::cerr << "FATAL: " << e.what() << "\n";
+        return 1;
+    }
+
     // Register auth middleware (runs before route handlers)
-    corvus::auth::register_jwt_middleware(validator);
+    corvus::auth::register_jwt_middleware(jwt_validator);
+    corvus::auth::register_api_key_middleware(api_key_validator);
 
     LOG_INFO << "Corvus " << corvus::version::string() << " starting";
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,9 +1,12 @@
+find_package(hiredis CONFIG REQUIRED)
+
 add_executable(corvus-unit-tests
   test_version.cpp
   test_health_handler.cpp
   test_router.cpp
   test_envelope.cpp
   test_jwt_validator.cpp
+  test_api_key_validator.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -18,6 +21,7 @@ target_link_libraries(corvus-unit-tests PRIVATE
   GTest::gtest_main
   GTest::gmock
   Drogon::Drogon
+  hiredis::hiredis
 )
 
 target_compile_features(corvus-unit-tests PRIVATE cxx_std_20)
@@ -31,5 +35,6 @@ gtest_add_tests(
               test_router.cpp
               test_envelope.cpp
               test_jwt_validator.cpp
+              test_api_key_validator.cpp
 )
 

--- a/tests/unit/test_api_key_validator.cpp
+++ b/tests/unit/test_api_key_validator.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+#include "corvus/auth/api_key_validator.h"
+#include <hiredis/hiredis.h>
+#include <cstdlib>
+#include <string>
+
+static std::string redis_host()
+{
+    const char *h = std::getenv("CORVUS_REDIS_HOST");
+    return (h && *h) ? h : "localhost";
+}
+
+static int redis_port()
+{
+    const char *p = std::getenv("CORVUS_REDIS_PORT");
+    return (p && *p) ? std::stoi(p) : 6379;
+}
+
+static bool redis_available()
+{
+    try
+    {
+        corvus::auth::ApiKeyValidator v{redis_host(), redis_port()};
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+static std::string seed_key(const std::string &client_id,
+                            const std::string &scopes = "read")
+{
+    const std::string raw_key = "test-key-" + client_id;
+    const std::string hash = corvus::auth::ApiKeyValidator::hash_key(raw_key);
+    const std::string rkey = "corvus:apikeys:" + hash;
+
+    redisContext *c = redisConnect(redis_host().c_str(), redis_port());
+    if (c && !c->err)
+    {
+        auto *r = static_cast<redisReply *>(
+            redisCommand(c, "HSET %s client_id %s scopes %s",
+                         rkey.c_str(), client_id.c_str(), scopes.c_str()));
+        if (r)
+            freeReplyObject(r);
+    }
+    if (c)
+        redisFree(c);
+
+    return raw_key;
+}
+
+class ApiKeyValidatorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        if (!redis_available())
+        {
+            GTEST_SKIP() << "Redis not reachable at "
+                         << redis_host() << ":" << redis_port()
+                         << " — skipping API key tests.";
+        }
+        validator_ = std::make_shared<corvus::auth::ApiKeyValidator>(
+            redis_host(), redis_port());
+    }
+
+    std::shared_ptr<corvus::auth::ApiKeyValidator> validator_;
+};
+
+TEST(ApiKeyHashTest, ProducesSha256Hex)
+{
+    EXPECT_EQ(
+        corvus::auth::ApiKeyValidator::hash_key("abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST(ApiKeyHashTest, DifferentInputsDifferentHashes)
+{
+    EXPECT_NE(corvus::auth::ApiKeyValidator::hash_key("key-a"),
+              corvus::auth::ApiKeyValidator::hash_key("key-b"));
+}
+
+TEST(ApiKeyValidatorConstructTest, ThrowsOnUnreachableRedis)
+{
+    EXPECT_THROW(
+        corvus::auth::ApiKeyValidator("127.0.0.1", 19999),
+        corvus::auth::ApiKeyConfigError);
+}
+
+TEST_F(ApiKeyValidatorTest, RejectsEmptyKey)
+{
+    EXPECT_THROW(validator_->validate(""),
+                 corvus::auth::ApiKeyValidationError);
+}
+
+TEST_F(ApiKeyValidatorTest, RejectsUnknownKey)
+{
+    EXPECT_THROW(validator_->validate("unknown-key-never-seeded"),
+                 corvus::auth::ApiKeyValidationError);
+}
+
+TEST_F(ApiKeyValidatorTest, AcceptsValidKey)
+{
+    const std::string raw = seed_key("svc-payments", "read write");
+    auto info = validator_->validate(raw);
+    EXPECT_EQ(info.client_id, "svc-payments");
+    EXPECT_EQ(info.scopes, "read write");
+}
+
+TEST_F(ApiKeyValidatorTest, HashIsDeterministic)
+{
+    const std::string raw = seed_key("svc-idempotent");
+    EXPECT_NO_THROW(validator_->validate(raw));
+    EXPECT_NO_THROW(validator_->validate(raw));
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,5 +2,12 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "corvus",
   "version": "0.1.0",
-  "dependencies": ["drogon", "gtest", "jwt-cpp", "nlohmann-json"]
+  "dependencies": [
+    "drogon",
+    "gtest",
+    "jwt-cpp",
+    "nlohmann-json",
+    "hiredis",
+    "openssl"
+  ]
 }


### PR DESCRIPTION
Closes CORV-16

Adds API key authentication middleware as a second auth layer on /v1/* routes.

- ApiKeyValidator SHA-256 hashes the raw key from X-Api-Key header and looks it up in Redis via HGETALL corvus:apikeys:<hash>
- Missing header, unknown hash, empty key, or Redis unavailable → 401 Envelope
- Runs after JWT middleware - both must pass for a request to reach a handler
- hiredis added to vcpkg and corvus-auth
- CORVUS_REDIS_HOST / CORVUS_REDIS_PORT read from env at startup (default localhost:6379)
- Server refuses to start if Redis is unreachable at startup
- Keys seeded as: HSET corvus:apikeys:<sha256(raw)> client_id <id> scopes <scopes>
- 5 unit tests: SHA-256 correctness, unknown key, empty key, valid key with metadata, deterministic hashing
- Redis-dependent tests skip cleanly if Redis is not available