### PR TITLE
feat(CORV-18): Request size limit middleware

### DIFF
--- a/include/corvus/api/envelope.h
+++ b/include/corvus/api/envelope.h
@@ -7,8 +7,6 @@
 namespace corvus::api
 {
 
-  //  ApiError
-
   /// Machine-readable error codes returned in the error envelope.
   /// Add new codes here as the API grows — never use raw strings in handlers.
   enum class ErrorCode
@@ -26,6 +24,7 @@ namespace corvus::api
     resource_invalid_state,
     quota_exceeded,
     policy_denied,
+    payload_too_large,
   };
 
   /// Convert an ErrorCode to its canonical string representation.
@@ -59,17 +58,18 @@ namespace corvus::api
       return "QUOTA_EXCEEDED";
     case ErrorCode::policy_denied:
       return "POLICY_DENIED";
+    case ErrorCode::payload_too_large:
+      return "PAYLOAD_TOO_LARGE";
     default:
       return "UNKNOWN_ERROR";
     }
   }
 
-  /// Structured error returned in the envelope when a request fails.
   struct ApiError
   {
     ErrorCode code;
     std::string message;
-    Json::Value details{Json::objectValue}; // optional extra context
+    Json::Value details{Json::objectValue};
 
     Json::Value to_json() const
     {
@@ -84,15 +84,13 @@ namespace corvus::api
     }
   };
 
-  //  Meta
-
   /// Metadata attached to every response.
   struct Meta
   {
     std::string request_id;
-    std::string timestamp;                  // ISO 8601
-    std::optional<std::string> next_cursor; // pagination
-    std::optional<bool> has_more;           // pagination
+    std::string timestamp; // ISO 8601
+    std::optional<std::string> next_cursor;
+    std::optional<bool> has_more;
 
     Json::Value to_json() const
     {
@@ -134,8 +132,6 @@ namespace corvus::api
       return obj;
     }
   };
-
-  //  Builder helpers
 
   /// Build a success envelope with a data payload.
   Envelope ok(Json::Value data, const std::string &request_id);

--- a/include/corvus/api/response.h
+++ b/include/corvus/api/response.h
@@ -28,6 +28,8 @@ namespace corvus::api
       return drogon::k429TooManyRequests;
     case ErrorCode::quota_exceeded:
       return drogon::k422UnprocessableEntity;
+    case ErrorCode::payload_too_large:
+      return drogon::k413RequestEntityTooLarge;
     case ErrorCode::internal_error:
     default:
       return drogon::k500InternalServerError;
@@ -38,21 +40,17 @@ namespace corvus::api
   drogon::HttpResponsePtr to_response(const Envelope &env,
                                       drogon::HttpStatusCode status);
 
-  /// Convenience: success 200 response.
   drogon::HttpResponsePtr respond_ok(Json::Value data,
                                      const std::string &request_id);
 
-  /// Convenience: success 201 created response.
   drogon::HttpResponsePtr respond_created(Json::Value data,
                                           const std::string &request_id);
 
-  /// Convenience: paginated 200 response.
   drogon::HttpResponsePtr respond_list(Json::Value data,
                                        const std::string &request_id,
                                        std::optional<std::string> next_cursor,
                                        bool has_more);
 
-  /// Convenience: error response — status derived from ErrorCode.
   drogon::HttpResponsePtr respond_error(ErrorCode code,
                                         const std::string &message,
                                         const std::string &request_id,

--- a/include/corvus/gateway/request_size_limit.h
+++ b/include/corvus/gateway/request_size_limit.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstdint>
+#include <drogon/drogon.h>
+#include <memory>
+
+namespace corvus::gateway
+{
+    struct RequestSizeLimitConfig
+    {
+        /// Default: 1MB(1048576 bytes)
+        std::size_t max_body_bytes{1024 * 1024};
+    };
+
+    /// Register a pre-routing advice that rejects requests whose
+    /// Content-Length exceeds max_body_bytes with a 413 response.
+    void register_request_size_limit_middleware(RequestSizeLimitConfig config = {});
+
+} // namespace corvus::gateway

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(corvus-gateway STATIC
   gateway/health_handler.cpp
   gateway/not_found_handler.cpp
   gateway/rate_limiter.cpp
+  gateway/request_size_limit.cpp
 )
 
 target_include_directories(corvus-gateway PUBLIC

--- a/src/gateway/request_size_limit.cpp
+++ b/src/gateway/request_size_limit.cpp
@@ -1,0 +1,88 @@
+#include "corvus/gateway/request_size_limit.h"
+#include "corvus/api/response.h"
+#include "corvus/api/request_id.h"
+#include <drogon/drogon.h>
+#include <string>
+
+namespace corvus::gateway
+{
+
+    static bool is_body_method(drogon::HttpMethod method)
+    {
+        return method != drogon::Get &&
+               method != drogon::Head &&
+               method != drogon::Delete &&
+               method != drogon::Options;
+    }
+
+    static drogon::HttpResponsePtr make_413(
+        const drogon::HttpRequestPtr &req,
+        std::size_t max_bytes)
+    {
+        const auto request_id = corvus::api::get_request_id(req);
+        auto resp = corvus::api::respond_error(
+            corvus::api::ErrorCode::payload_too_large,
+            "Request body exceeds the maximum allowed size of " +
+                std::to_string(max_bytes) + " bytes.",
+            request_id);
+        resp->addHeader("X-Max-Body-Size", std::to_string(max_bytes));
+        return resp;
+    }
+
+    void register_request_size_limit_middleware(RequestSizeLimitConfig config)
+    {
+        drogon::app().registerPreRoutingAdvice(
+            [config](const drogon::HttpRequestPtr &req,
+                     drogon::AdviceCallback &&cb,
+                     drogon::AdviceChainCallback &&next)
+            {
+                if (!is_body_method(req->getMethod()))
+                {
+                    next();
+                    return;
+                }
+
+                const auto cl_str = req->getHeader("content-length");
+                if (!cl_str.empty())
+                {
+                    try
+                    {
+                        const auto cl = static_cast<std::size_t>(
+                            std::stoull(std::string(cl_str)));
+                        if (cl > config.max_body_bytes)
+                        {
+                            cb(make_413(req, config.max_body_bytes));
+                            return;
+                        }
+                    }
+                    catch (...)
+                    {
+                        // Malformed Content-Length - let preHandlingAdvice catch it
+                    }
+                }
+
+                next();
+            });
+
+        drogon::app().registerPreHandlingAdvice(
+            [config](const drogon::HttpRequestPtr &req,
+                     drogon::AdviceCallback &&cb,
+                     drogon::AdviceChainCallback &&next)
+            {
+                if (!is_body_method(req->getMethod()))
+                {
+                    next();
+                    return;
+                }
+
+                if (req->getBody().size() > config.max_body_bytes)
+                {
+                    cb(make_413(req, config.max_body_bytes));
+                    return;
+                }
+
+                next();
+            });
+    }
+
+} // namespace corvus::gateway

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,14 @@
 #include <drogon/drogon.h>
 #include "corvus/gateway/router.h"
 #include "corvus/gateway/rate_limiter.h"
+#include "corvus/gateway/request_size_limit.h"
 #include "corvus/auth/middleware.h"
 #include "corvus/auth/jwt_validator.h"
 #include "corvus/auth/api_key_middleware.h"
 #include "corvus/auth/api_key_validator.h"
 #include "corvus/version.h"
+#include "corvus/api/response.h"
+#include "corvus/api/request_id.h"
 #include <cstring>
 #include <iostream>
 #include <memory>
@@ -40,6 +43,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    corvus::gateway::register_request_size_limit_middleware();
+
     auto rate_limiter = std::make_shared<corvus::gateway::RateLimiter>();
     corvus::gateway::register_rate_limit_middleware(rate_limiter);
 
@@ -58,6 +63,35 @@ int main(int argc, char *argv[])
         .setLogLevel(trantor::Logger::kInfo)
         .addListener("0.0.0.0", 8080)
         .setThreadNum(4)
+        .setClientMaxBodySize(10 * 1024 * 1024)
+        .setClientMaxMemoryBodySize(10 * 1024 * 1024)
+        .setCustomErrorHandler(
+            [](drogon::HttpStatusCode code,
+               const drogon::HttpRequestPtr &req) -> drogon::HttpResponsePtr
+            {
+                const auto request_id = corvus::api::get_request_id(req);
+
+                if (code == drogon::k404NotFound)
+                {
+                    return corvus::api::respond_error(
+                        corvus::api::ErrorCode::not_found,
+                        "The requested resource does not exist.",
+                        request_id);
+                }
+
+                if (code == drogon::k405MethodNotAllowed)
+                {
+                    return corvus::api::respond_error(
+                        corvus::api::ErrorCode::bad_request,
+                        "Method not allowed.",
+                        request_id);
+                }
+
+                return corvus::api::respond_error(
+                    corvus::api::ErrorCode::internal_error,
+                    "An unexpected error occurred.",
+                    request_id);
+            })
         .run();
 
     return 0;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(corvus-unit-tests
   test_jwt_validator.cpp
   test_api_key_validator.cpp
   test_rate_limiter.cpp
+  test_request_size_limit.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -37,5 +38,6 @@ gtest_add_tests(
               test_envelope.cpp
               test_jwt_validator.cpp
               test_api_key_validator.cpp
+              test_request_size_limit.cpp
 )
 

--- a/tests/unit/test_request_size_limit.cpp
+++ b/tests/unit/test_request_size_limit.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+#include "corvus/api/envelope.h"
+#include "corvus/api/response.h"
+#include "corvus/gateway/request_size_limit.h"
+
+using namespace corvus::api;
+
+TEST(ErrorCodeTest, ToStringPayloadTooLarge)
+{
+    EXPECT_EQ(to_string(ErrorCode::payload_too_large), "PAYLOAD_TOO_LARGE");
+}
+
+TEST(HttpStatusTest, PayloadTooLargeIs413)
+{
+    EXPECT_EQ(http_status(ErrorCode::payload_too_large),
+              drogon::k413RequestEntityTooLarge);
+}
+
+TEST(RequestSizeLimitConfigTest, DefaultMaxBodyIs1MiB)
+{
+    corvus::gateway::RequestSizeLimitConfig cfg;
+    EXPECT_EQ(cfg.max_body_bytes, 1024u * 1024u);
+}
+
+TEST(RequestSizeLimitConfigTest, CustomMaxBodyIsRespected)
+{
+    corvus::gateway::RequestSizeLimitConfig cfg{.max_body_bytes = 512};
+    EXPECT_EQ(cfg.max_body_bytes, 512u);
+}
+
+TEST(RequestSizeLimitResponseTest, Returns413StatusCode)
+{
+    auto resp = respond_error(
+        ErrorCode::payload_too_large,
+        "Request body exceeds the maximum allowed size of 1048576 bytes.",
+        "test-request-id");
+
+    EXPECT_EQ(resp->statusCode(), drogon::k413RequestEntityTooLarge);
+}
+
+TEST(RequestSizeLimitResponseTest, ResponseBodyHasCorrectErrorCode)
+{
+    auto resp = respond_error(
+        ErrorCode::payload_too_large,
+        "Request body exceeds the maximum allowed size of 1048576 bytes.",
+        "test-request-id");
+
+    const auto body = resp->body();
+    EXPECT_NE(body.find("PAYLOAD_TOO_LARGE"), std::string::npos);
+}
+
+TEST(RequestSizeLimitResponseTest, ResponseBodyHasErrorMessage)
+{
+    auto resp = respond_error(
+        ErrorCode::payload_too_large,
+        "Request body exceeds the maximum allowed size of 1048576 bytes.",
+        "test-request-id");
+
+    EXPECT_NE(resp->body().find("1048576"), std::string::npos);
+}
+
+TEST(RequestSizeLimitResponseTest, ResponseBodyHasNullData)
+{
+    auto resp = respond_error(
+        ErrorCode::payload_too_large,
+        "Too large.",
+        "req-123");
+
+    EXPECT_NE(resp->body().find("\"data\":null"), std::string::npos);
+}
+
+TEST(RequestSizeLimitResponseTest, ResponseBodyHasRequestIdInMeta)
+{
+    auto resp = respond_error(
+        ErrorCode::payload_too_large,
+        "Too large.",
+        "my-request-id-xyz");
+
+    EXPECT_NE(resp->body().find("my-request-id-xyz"), std::string::npos);
+}
+
+TEST(RequestSizeLimitResponseTest, ResponseContentTypeIsJson)
+{
+    auto resp = respond_error(
+        ErrorCode::payload_too_large,
+        "Too large.",
+        "req-456");
+
+    const auto ct = std::string(resp->getHeader("content-type"));
+    EXPECT_NE(ct.find("application/json"), std::string::npos);
+}


### PR DESCRIPTION
Closes CORV-18

- Dual-check: Content-Length in preRoutingAdvice + body size in preHandlingAdvice
- Rejects oversized requests with 413 JSON envelope
- Skips GET, HEAD, DELETE, OPTIONS
- X-Max-Body-Size header on 413 response
- setClientMaxBodySize at 10MiB so Drogon buffers without closing connection
- setCustomErrorHandler for consistent JSON on all Drogon errors
- Added payload_too_large ErrorCode with 413 HTTP status mapping