### PR TITLE
feat(CORV-19): Request ID Middleware

### DIFF
--- a/include/corvus/gateway/request_id_middleware.h
+++ b/include/corvus/gateway/request_id_middleware.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <drogon/drogon.h>
+
+namespace corvus::gateway
+{
+    /// Register a pre-routing advice that ensures every request has a
+    /// stable request ID for its entire lifetime.
+    void register_request_id_middleware();
+
+} // namespace corvus::gateway

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(corvus-gateway STATIC
   gateway/not_found_handler.cpp
   gateway/rate_limiter.cpp
   gateway/request_size_limit.cpp
+  gateway/request_id_middleware.cpp
 )
 
 target_include_directories(corvus-gateway PUBLIC

--- a/src/gateway/request_id_middleware.cpp
+++ b/src/gateway/request_id_middleware.cpp
@@ -1,0 +1,40 @@
+#include "corvus/gateway/request_id_middleware.h"
+#include "corvus/api/request_id.h"
+#include <drogon/drogon.h>
+#include <string>
+
+namespace corvus::gateway
+{
+    void register_request_id_middleware()
+    {
+        // Pre-routing: inject the request ID into attributes before
+        // any other middleware or handler runs.
+        drogon::app().registerPreRoutingAdvice(
+            [](const drogon::HttpRequestPtr &req,
+               drogon::AdviceCallback &&,
+               drogon::AdviceChainCallback &&next)
+            {
+                std::string request_id;
+                const auto header = req->getHeader("X-Request-ID");
+                if (!header.empty())
+                {
+                    request_id = std::string(header);
+                }
+                else
+                {
+                    request_id = corvus::api::generate_uuid();
+                }
+                req->getAttributes()->insert(corvus::api::kRequestIdKey, request_id);
+
+                next();
+            });
+
+        drogon::app().registerPostHandlingAdvice(
+            [](const drogon::HttpRequestPtr &req,
+               const drogon::HttpResponsePtr &resp)
+            {
+                const auto request_id = corvus::api::get_request_id(req);
+                resp->addHeader("X-Request-ID", request_id);
+            });
+    }
+} // namespace corvus::gateway

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "corvus/gateway/router.h"
 #include "corvus/gateway/rate_limiter.h"
 #include "corvus/gateway/request_size_limit.h"
+#include "corvus/gateway/request_id_middleware.h"
 #include "corvus/auth/middleware.h"
 #include "corvus/auth/jwt_validator.h"
 #include "corvus/auth/api_key_middleware.h"
@@ -43,6 +44,8 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    corvus::gateway::register_request_id_middleware();
+
     corvus::gateway::register_request_size_limit_middleware();
 
     auto rate_limiter = std::make_shared<corvus::gateway::RateLimiter>();
@@ -71,26 +74,32 @@ int main(int argc, char *argv[])
             {
                 const auto request_id = corvus::api::get_request_id(req);
 
+                drogon::HttpResponsePtr resp;
+
                 if (code == drogon::k404NotFound)
                 {
-                    return corvus::api::respond_error(
+                    resp = corvus::api::respond_error(
                         corvus::api::ErrorCode::not_found,
                         "The requested resource does not exist.",
                         request_id);
                 }
-
-                if (code == drogon::k405MethodNotAllowed)
+                else if (code == drogon::k405MethodNotAllowed)
                 {
-                    return corvus::api::respond_error(
+                    resp = corvus::api::respond_error(
                         corvus::api::ErrorCode::bad_request,
                         "Method not allowed.",
                         request_id);
                 }
+                else
+                {
+                    resp = corvus::api::respond_error(
+                        corvus::api::ErrorCode::internal_error,
+                        "An unexpected error occurred.",
+                        request_id);
+                }
 
-                return corvus::api::respond_error(
-                    corvus::api::ErrorCode::internal_error,
-                    "An unexpected error occurred.",
-                    request_id);
+                resp->addHeader("X-Request-ID", request_id);
+                return resp;
             })
         .run();
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(corvus-unit-tests
   test_api_key_validator.cpp
   test_rate_limiter.cpp
   test_request_size_limit.cpp
+  test_request_id.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -39,5 +40,6 @@ gtest_add_tests(
               test_jwt_validator.cpp
               test_api_key_validator.cpp
               test_request_size_limit.cpp
+              test_request_id.cpp
 )
 

--- a/tests/unit/test_request_id.cpp
+++ b/tests/unit/test_request_id.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+#include "corvus/api/request_id.h"
+#include <drogon/drogon.h>
+#include <regex>
+#include <set>
+
+using namespace corvus::api;
+
+TEST(RequestIdTest, GenerateUuidIsNonEmpty)
+{
+    EXPECT_FALSE(generate_uuid().empty());
+}
+
+TEST(RequestIdTest, GenerateUuidHasCorrectFormat)
+{
+    const auto uuid = generate_uuid();
+    const std::regex uuid_re(
+        "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
+    EXPECT_TRUE(std::regex_match(uuid, uuid_re))
+        << "UUID was: " << uuid;
+}
+
+TEST(RequestIdTest, GenerateUuidVersion4Bit)
+{
+    const auto uuid = generate_uuid();
+    EXPECT_EQ(uuid[14], '4');
+}
+
+TEST(RequestIdTest, GenerateUuidVariantBits)
+{
+    const auto uuid = generate_uuid();
+    const char variant = uuid[19];
+    EXPECT_TRUE(variant == '8' || variant == '9' ||
+                variant == 'a' || variant == 'b')
+        << "Variant char was: " << variant;
+}
+
+TEST(RequestIdTest, GenerateUuidIsUnique)
+{
+    std::set<std::string> ids;
+    for (int i = 0; i < 1000; ++i)
+    {
+        ids.insert(generate_uuid());
+    }
+    EXPECT_EQ(ids.size(), 1000u);
+}
+
+TEST(RequestIdTest, GenerateUuidLength)
+{
+    EXPECT_EQ(generate_uuid().size(), 36u);
+}
+
+TEST(RequestIdTest, GetRequestIdFromAttributes)
+{
+    auto req = drogon::HttpRequest::newHttpRequest();
+    req->getAttributes()->insert(kRequestIdKey, std::string("test-id-123"));
+
+    EXPECT_EQ(get_request_id(req), "test-id-123");
+}
+
+TEST(RequestIdTest, GetRequestIdFromXRequestIdHeader)
+{
+    auto req = drogon::HttpRequest::newHttpRequest();
+    req->addHeader("X-Request-ID", "header-id-456");
+
+    EXPECT_EQ(get_request_id(req), "header-id-456");
+}
+
+TEST(RequestIdTest, GetRequestIdAttributesTakesPrecedenceOverHeader)
+{
+    auto req = drogon::HttpRequest::newHttpRequest();
+    req->getAttributes()->insert(kRequestIdKey, std::string("attr-id"));
+    req->addHeader("X-Request-ID", "header-id");
+
+    EXPECT_EQ(get_request_id(req), "attr-id");
+}
+
+TEST(RequestIdTest, GetRequestIdGeneratesUuidWhenNonePresent)
+{
+    auto req = drogon::HttpRequest::newHttpRequest();
+    const auto id = get_request_id(req);
+
+    EXPECT_FALSE(id.empty());
+    EXPECT_EQ(id.size(), 36u);
+}
+
+TEST(RequestIdTest, GetRequestIdIsStableOnceSetInAttributes)
+{
+    auto req = drogon::HttpRequest::newHttpRequest();
+    req->getAttributes()->insert(kRequestIdKey, std::string("stable-id"));
+
+    EXPECT_EQ(get_request_id(req), "stable-id");
+    EXPECT_EQ(get_request_id(req), "stable-id");
+    EXPECT_EQ(get_request_id(req), "stable-id");
+}
+
+TEST(RequestIdTest, GenerateUuidIsDifferentAcrossThreads)
+{
+    constexpr std::size_t num_threads = 4;
+    constexpr std::size_t per_thread = 250;
+
+    std::vector<std::vector<std::string>> results(num_threads);
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (std::size_t t = 0; t < num_threads; ++t)
+    {
+        threads.emplace_back([&results, t]()
+                             {
+            for (std::size_t i = 0; i < per_thread; ++i)
+                results[t].push_back(generate_uuid()); });
+    }
+
+    for (auto &th : threads)
+        th.join();
+
+    std::set<std::string> all;
+    for (const auto &v : results)
+        all.insert(v.begin(), v.end());
+
+    EXPECT_EQ(all.size(), num_threads * per_thread);
+}


### PR DESCRIPTION
Closes CORV-19

- Injects stable UUID v4 per request via registerPreRoutingAdvice
- Adopts upstream X-Request-ID header if present
- Echoes ID back in x-request-id response header
- postHandlingAdvice + manual header in setCustomErrorHandler for full coverage
- get_request_id() now stable across all middleware and handlers
- Registered first in middleware chain