### PR TITLE
feat(CORV-20): auth integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python test deps
-        run: pip install pytest httpx
+        run: pip install -r requirements-dev.txt
 
       - name: Generate test JWT keypair
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,6 @@ pytest>=8.0
 pytest-asyncio>=0.23
 ruff>=0.4
 pydantic>=2.0
+PyJWT>=2.8
+cryptography>=42.0
+redis>=5.0

--- a/src/auth/api_key_middleware.cpp
+++ b/src/auth/api_key_middleware.cpp
@@ -19,14 +19,16 @@ namespace corvus::auth
                     return;
                 }
 
+                const auto request_id = corvus::api::get_request_id(req);
                 const std::string raw_key = req->getHeader("X-Api-Key");
                 if (raw_key.empty())
                 {
-                    const auto request_id = corvus::api::get_request_id(req);
-                    cb(corvus::api::respond_error(
+                    auto resp = corvus::api::respond_error(
                         corvus::api::ErrorCode::unauthorized,
                         "Missing X-Api-Key header",
-                        request_id));
+                        request_id);
+                    resp->addHeader("X-Request-ID", request_id);
+                    cb(resp);
                     return;
                 }
 
@@ -37,11 +39,12 @@ namespace corvus::auth
                 }
                 catch (const ApiKeyValidationError &e)
                 {
-                    const auto request_id = corvus::api::get_request_id(req);
-                    cb(corvus::api::respond_error(
+                    auto resp = corvus::api::respond_error(
                         corvus::api::ErrorCode::unauthorized,
                         std::string("Invalid API key: ") + e.what(),
-                        request_id));
+                        request_id);
+                    resp->addHeader("X-Request-ID", request_id);
+                    cb(resp);
                 }
             });
     }

--- a/src/auth/middleware.cpp
+++ b/src/auth/middleware.cpp
@@ -18,16 +18,19 @@ namespace corvus::auth
                     return;
                 }
 
+                const auto request_id = corvus::api::get_request_id(req);
+
                 // Extract Bearer token
                 const std::string auth_header = req->getHeader("Authorization");
                 const std::string prefix = "Bearer ";
                 if (auth_header.empty() || auth_header.rfind(prefix, 0) != 0)
                 {
-                    const auto request_id = corvus::api::get_request_id(req);
-                    cb(corvus::api::respond_error(
+                    auto resp = corvus::api::respond_error(
                         corvus::api::ErrorCode::unauthorized,
                         "Missing or malformed Authorization header",
-                        request_id));
+                        request_id);
+                    resp->addHeader("X-Request-ID", request_id);
+                    cb(resp);
                     return;
                 }
 
@@ -35,15 +38,16 @@ namespace corvus::auth
                 try
                 {
                     validator->validate(token);
-                    next(); // Token valid, proceed to the next handler
+                    next();
                 }
                 catch (const JwtValidationError &e)
                 {
-                    const auto request_id = corvus::api::get_request_id(req);
-                    cb(corvus::api::respond_error(
+                    auto resp = corvus::api::respond_error(
                         corvus::api::ErrorCode::unauthorized,
                         std::string("Invalid token: ") + e.what(),
-                        request_id));
+                        request_id);
+                    resp->addHeader("X-Request-ID", request_id);
+                    cb(resp);
                 }
             });
     }

--- a/src/gateway/router.cpp
+++ b/src/gateway/router.cpp
@@ -28,17 +28,37 @@ namespace corvus::gateway
             {drogon::Get});
 
         auto nf = not_found_handler();
-        drogon::app().setCustomErrorHandler([nf](drogon::HttpStatusCode code, const drogon::HttpRequestPtr &req) -> drogon::HttpResponsePtr
-                                            {
-        if(code ==drogon::k404NotFound){
-            const auto request_id = corvus::api::get_request_id(req);
-            return corvus::api::respond_error(
-                corvus::api::ErrorCode::not_found,
-                "The request path '" + req->getPath() + "' does not exist",
-                request_id);
-            }
+        const std::vector<drogon::internal::HttpConstraint> all_methods = {
+            drogon::Get, drogon::Post, drogon::Put,
+            drogon::Patch, drogon::Delete, drogon::Options};
 
-        return drogon::HttpResponse::newHttpResponse(); });
+        drogon::app().registerHandler(
+            "/{a}",
+            [nf](const drogon::HttpRequestPtr &req,
+                std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { nf(req, std::move(cb)); },
+            all_methods);
+
+        drogon::app().registerHandler(
+            "/{a}/{b}",
+            [nf](const drogon::HttpRequestPtr &req,
+                std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { nf(req, std::move(cb)); },
+            all_methods);
+
+        drogon::app().registerHandler(
+            "/{a}/{b}/{c}",
+            [nf](const drogon::HttpRequestPtr &req,
+                std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { nf(req, std::move(cb)); },
+            all_methods);
+
+        drogon::app().registerHandler(
+            "/{a}/{b}/{c}/{d}",
+            [nf](const drogon::HttpRequestPtr &req,
+                std::function<void(const drogon::HttpResponsePtr &)> &&cb)
+            { nf(req, std::move(cb)); },
+            all_methods);
         LOG_INFO << "Routes registered";
     }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,123 @@
+"""
+Shared fixtures for Corvus integration tests.
+
+Requires:
+  CORVUS_TEST_PRIVATE_KEY  - RSA private key PEM (for signing test JWTs)
+  CORVUS_TEST_PUBLIC_KEY   - RSA public key PEM  (informational, not used here)
+  CORVUS_BASE_URL          - defaults to http://localhost:8080
+  CORVUS_REDIS_HOST        - defaults to localhost
+  CORVUS_REDIS_PORT        - defaults to 6379
+"""
+
+import os
+import time
+import hashlib
+import pytest
+import httpx
+import redis as redis_client
+
+from datetime import datetime, timedelta, timezone
+
+try:
+    import jwt as pyjwt
+except ImportError:
+    pyjwt = None
+
+BASE_URL = os.environ.get("CORVUS_BASE_URL", "http://localhost:8080")
+REDIS_HOST = os.environ.get("CORVUS_REDIS_HOST", "localhost")
+REDIS_PORT = int(os.environ.get("CORVUS_REDIS_PORT", "6380"))
+PRIVATE_KEY = os.environ.get("CORVUS_TEST_PRIVATE_KEY", "")
+
+
+def make_jwt(
+    subject: str = "test-user",
+    issuer: str = "corvus-test",
+    expires_in: int = 300,
+    private_key: str | None = None,
+    algorithm: str = "RS256",
+) -> str:
+    """Sign a JWT with the test private key."""
+    if pyjwt is None:
+        raise RuntimeError("PyJWT not installed")
+
+    key = private_key or PRIVATE_KEY
+    if not key:
+        raise RuntimeError("CORVUS_TEST_PRIVATE_KEY is not set")
+
+    now = datetime.now(tz=timezone.utc)
+    payload = {
+        "sub": subject,
+        "iss": issuer,
+        "iat": now,
+        "exp": now + timedelta(seconds=expires_in),
+    }
+    return pyjwt.encode(payload, key, algorithm=algorithm)
+
+
+def make_expired_jwt() -> str:
+    """Return a JWT that expired 1 minute ago."""
+    return make_jwt(expires_in=-60)
+
+
+def sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def redis_key(api_key: str) -> str:
+    return f"corvus:apikeys:{sha256_hex(api_key)}"
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    return BASE_URL
+
+
+@pytest.fixture(scope="session")
+def client() -> httpx.Client:
+    with httpx.Client(base_url=BASE_URL, timeout=10.0) as client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def redis() -> redis_client.Redis:
+    r = redis_client.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+    try:
+        r.ping()
+    except Exception as e:
+        pytest.skip(f"Redis not reachable at {REDIS_HOST}:{REDIS_PORT} - {e}")
+    return r
+
+
+@pytest.fixture(scope="session")
+def valid_jwt() -> str:
+    return make_jwt()
+
+
+@pytest.fixture(scope="session")
+def expired_jwt() -> str:
+    return make_expired_jwt()
+
+
+@pytest.fixture
+def api_key(redis) -> str:
+    """Register a fresh API key in Redis and clean it up after the test."""
+    raw_key = f"test-key-{time.time_ns()}"
+    rkey = redis_key(raw_key)
+    redis.hset(rkey, mapping={"client_id": "test-client", "scopes": "read"})
+    yield raw_key
+    redis.delete(rkey)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def wait_for_server():
+    """Block until corvus-core is healthy before running any test."""
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            resp = httpx.get(f"{BASE_URL}/health", timeout=2.0)
+            if resp.status_code == 200:
+                return
+        except httpx.RequestError:
+            pass
+        time.sleep(1)
+    pytest.fail(f"corvus-core did not become healthy within 60s at {BASE_URL}")

--- a/tests/integration/test_auth_api_key.py
+++ b/tests/integration/test_auth_api_key.py
@@ -1,0 +1,145 @@
+import pytest
+import httpx
+from conftest import make_jwt
+
+
+class TestApiKeyMissing:
+    def test_missing_api_key_with_valid_jwt_returns_401(self, client, valid_jwt):
+        resp = client.get(
+            "/v1/anything",
+            headers={"Authorization": f"Bearer {valid_jwt}"},
+        )
+        assert resp.status_code == 401
+
+    def test_missing_api_key_error_code(self, client, valid_jwt):
+        body = client.get(
+            "/v1/anything",
+            headers={"Authorization": f"Bearer {valid_jwt}"},
+        ).json()
+        assert body["error"]["code"] == "UNAUTHORIZED"
+
+    def test_missing_api_key_mentions_header_name(self, client, valid_jwt):
+        body = client.get(
+            "/v1/anything",
+            headers={"Authorization": f"Bearer {valid_jwt}"},
+        ).json()
+        assert "X-Api-Key" in body["error"]["message"]
+
+    def test_missing_api_key_data_is_null(self, client, valid_jwt):
+        body = client.get(
+            "/v1/anything",
+            headers={"Authorization": f"Bearer {valid_jwt}"},
+        ).json()
+        assert body["data"] is None
+
+
+class TestApiKeyInvalid:
+    def test_unknown_api_key_returns_401(self, client, valid_jwt):
+        resp = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": "completely-unknown-key",
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_unknown_api_key_error_code(self, client, valid_jwt):
+        body = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": "completely-unknown-key",
+            },
+        ).json()
+        assert body["error"]["code"] == "UNAUTHORIZED"
+
+    def test_empty_api_key_returns_401(self, client, valid_jwt):
+        resp = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": "",
+            },
+        )
+        assert resp.status_code == 401
+
+
+class TestApiKeyValid:
+    def test_valid_api_key_with_valid_jwt_passes_auth(self, client, valid_jwt, api_key):
+        """Both JWT and API key valid."""
+        resp = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": api_key,
+            },
+        )
+        # Auth passes, route doesn't exist
+        assert resp.status_code == 404
+
+    def test_valid_api_key_response_has_envelope(self, client, valid_jwt, api_key):
+        body = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": api_key,
+            },
+        ).json()
+        assert "data" in body
+        assert "error" in body
+        assert "meta" in body
+
+    def test_valid_api_key_404_error_code(self, client, valid_jwt, api_key):
+        body = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": api_key,
+            },
+        ).json()
+        assert body["error"]["code"] == "NOT_FOUND"
+
+    def test_valid_api_key_request_id_consistent(self, client, valid_jwt, api_key):
+        resp = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": api_key,
+            },
+        )
+        assert resp.headers["x-request-id"] == resp.json()["meta"]["request_id"]
+
+    def test_api_key_not_required_on_health(self, client):
+        """Health endpoint requires no API key."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_revoked_api_key_returns_401(self, client, valid_jwt, redis):
+        """Delete the key from Redis mid-test to simulate revocation."""
+        from conftest import redis_key, sha256_hex
+        import time
+
+        raw_key = f"revoke-test-{time.time_ns()}"
+        rkey = redis_key(raw_key)
+        redis.hset(rkey, mapping={"client_id": "revoke-client", "scopes": "read"})
+
+        resp = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": raw_key,
+            },
+        )
+        assert resp.status_code == 404
+
+        redis.delete(rkey)
+
+        resp = client.get(
+            "/v1/anything",
+            headers={
+                "Authorization": f"Bearer {valid_jwt}",
+                "X-Api-Key": raw_key,
+            },
+        )
+        assert resp.status_code == 401

--- a/tests/integration/test_auth_jwt.py
+++ b/tests/integration/test_auth_jwt.py
@@ -1,0 +1,113 @@
+import pytest
+import httpx
+from conftest import make_jwt, make_expired_jwt
+
+
+class TestJwtMissingHeader:
+    def test_missing_auth_header_returns_401(self, client):
+        resp = client.get("/v1/anything")
+        assert resp.status_code == 401
+
+    def test_missing_auth_header_error_code(self, client):
+        body = client.get("/v1/anything").json()
+        assert body["error"]["code"] == "UNAUTHORIZED"
+
+    def test_missing_auth_header_error_message(self, client):
+        body = client.get("/v1/anything").json()
+        assert "Authorization" in body["error"]["message"]
+
+    def test_missing_auth_header_has_request_id(self, client):
+        body = client.get("/v1/anything").json()
+        assert len(body["meta"]["request_id"]) == 36
+
+    def test_missing_auth_header_x_request_id_in_response(self, client):
+        resp = client.get("/v1/anything")
+        assert "x-request-id" in resp.headers
+
+    def test_missing_auth_header_data_is_null(self, client):
+        body = client.get("/v1/anything").json()
+        assert body["data"] is None
+
+
+class TestJwtMalformedHeader:
+    def test_malformed_bearer_returns_401(self, client):
+        resp = client.get("/v1/anything", headers={"Authorization": "notbearer token"})
+        assert resp.status_code == 401
+
+    def test_no_bearer_prefix_returns_401(self, client):
+        resp = client.get("/v1/anything", headers={"Authorization": "sometoken"})
+        assert resp.status_code == 401
+
+    def test_empty_bearer_returns_401(self, client):
+        resp = client.get("/v1/anything", headers={"Authorization": "Bearer x"})
+        assert resp.status_code == 401
+
+
+class TestJwtInvalidToken:
+    def test_garbage_token_returns_401(self, client):
+        resp = client.get(
+            "/v1/anything", headers={"Authorization": "Bearer notavalidtoken"}
+        )
+        assert resp.status_code == 401
+
+    def test_garbage_token_error_code(self, client):
+        body = client.get(
+            "/v1/anything", headers={"Authorization": "Bearer notavalidtoken"}
+        ).json()
+        assert body["error"]["code"] == "UNAUTHORIZED"
+
+    def test_expired_token_returns_401(self, client, expired_jwt):
+        resp = client.get(
+            "/v1/anything", headers={"Authorization": f"Bearer {expired_jwt}"}
+        )
+        assert resp.status_code == 401
+
+    def test_expired_token_error_message_mentions_token(self, client, expired_jwt):
+        body = client.get(
+            "/v1/anything", headers={"Authorization": f"Bearer {expired_jwt}"}
+        ).json()
+        assert body["error"]["message"] != ""
+
+    def test_wrong_algorithm_token_returns_401(self, client):
+        """HS256-signed token must be rejected."""
+        import jwt as pyjwt
+        from datetime import datetime, timedelta, timezone
+
+        hs_token = pyjwt.encode(
+            {
+                "sub": "user",
+                "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=5),
+            },
+            "secret",
+            algorithm="HS256",
+        )
+        resp = client.get(
+            "/v1/anything", headers={"Authorization": f"Bearer {hs_token}"}
+        )
+        assert resp.status_code == 401
+
+
+class TestJwtValidToken:
+    def test_valid_token_passes_jwt_check(self, client, valid_jwt):
+        """With valid JWT, auth passes."""
+        resp = client.get(
+            "/v1/anything", headers={"Authorization": f"Bearer {valid_jwt}"}
+        )
+        assert resp.status_code == 401
+        body = resp.json()
+        assert "X-Api-Key" in body["error"]["message"]
+
+    def test_valid_token_not_rate_limited_on_health(self, client, valid_jwt):
+        """Health endpoint ignores JWT entirely."""
+        resp = client.get("/health", headers={"Authorization": f"Bearer {valid_jwt}"})
+        assert resp.status_code == 200
+
+    def test_jwt_not_checked_on_health(self, client):
+        """Health endpoint requires no auth."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_jwt_not_checked_on_ready(self, client):
+        """Ready endpoint requires no auth."""
+        resp = client.get("/ready")
+        assert resp.status_code == 200

--- a/tests/integration/test_envelope.py
+++ b/tests/integration/test_envelope.py
@@ -1,0 +1,81 @@
+import pytest
+import httpx
+
+
+class TestNotFoundEnvelope:
+    def test_unknown_path_returns_404(self, client):
+        resp = client.get("/nonexistent")
+        assert resp.status_code == 404
+
+    def test_unknown_nested_path_returns_404(self, client):
+        resp = client.get("/a/b/c")
+        assert resp.status_code == 404
+
+    def test_404_has_json_content_type(self, client):
+        resp = client.get("/nonexistent")
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_404_envelope_shape(self, client):
+        body = client.get("/nonexistent").json()
+        assert "data" in body
+        assert "error" in body
+        assert "meta" in body
+
+    def test_404_error_code_is_not_found(self, client):
+        body = client.get("/nonexistent").json()
+        assert body["error"]["code"] == "NOT_FOUND"
+
+    def test_404_data_is_null(self, client):
+        body = client.get("/nonexistent").json()
+        assert body["data"] is None
+
+    def test_404_has_request_id_in_meta(self, client):
+        body = client.get("/nonexistent").json()
+        assert len(body["meta"]["request_id"]) == 36
+
+    def test_404_has_x_request_id_header(self, client):
+        resp = client.get("/nonexistent")
+        assert "x-request-id" in resp.headers
+
+    def test_404_header_matches_body_request_id(self, client):
+        resp = client.get("/nonexistent")
+        assert resp.headers["x-request-id"] == resp.json()["meta"]["request_id"]
+
+    def test_404_has_timestamp_in_meta(self, client):
+        body = client.get("/nonexistent").json()
+        assert "timestamp" in body["meta"]
+        assert body["meta"]["timestamp"] != ""
+
+
+class TestEnvelopeConsistency:
+    """All error types must return consistent envelope shape."""
+
+    def _assert_envelope(self, resp, expected_status: int, expected_code: str):
+        assert resp.status_code == expected_status
+        assert "application/json" in resp.headers["content-type"]
+        body = resp.json()
+        assert body["data"] is None
+        assert body["error"]["code"] == expected_code
+        assert len(body["meta"]["request_id"]) == 36
+        assert "x-request-id" in resp.headers
+        assert resp.headers["x-request-id"] == body["meta"]["request_id"]
+
+    def test_401_envelope(self, client):
+        self._assert_envelope(client.get("/v1/anything"), 401, "UNAUTHORIZED")
+
+    def test_404_envelope(self, client):
+        self._assert_envelope(client.get("/does-not-exist"), 404, "NOT_FOUND")
+
+    def test_413_envelope(self, client):
+        resp = client.post(
+            "/v1/anything",
+            content=b"x" * (1024 * 1024 + 1),
+            headers={"Content-Type": "application/octet-stream", "Expect": ""},
+        )
+        assert resp.status_code == 413
+        assert "application/json" in resp.headers["content-type"]
+        body = resp.json()
+        assert body["data"] is None
+        assert body["error"]["code"] == "PAYLOAD_TOO_LARGE"
+        assert len(body["meta"]["request_id"]) == 36
+        assert body["meta"]["request_id"] != ""

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -1,0 +1,87 @@
+"""
+Integration tests - health and readiness endpoints.
+These run against a live corvus-core instance.
+"""
+
+import pytest
+import httpx
+
+
+class TestHealth:
+    def test_health_returns_200(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_health_content_type_is_json(self, client):
+        resp = client.get("/health")
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_health_envelope_shape(self, client):
+        body = client.get("/health").json()
+        assert "data" in body
+        assert "error" in body
+        assert "meta" in body
+        assert body["error"] is None
+
+    def test_health_data_status_is_ok(self, client):
+        body = client.get("/health").json()
+        assert body["data"]["status"] == "ok"
+
+    def test_health_data_has_version(self, client):
+        body = client.get("/health").json()
+        assert "version" in body["data"]
+        assert body["data"]["version"] != ""
+
+    def test_health_meta_has_request_id(self, client):
+        body = client.get("/health").json()
+        assert "request_id" in body["meta"]
+        assert len(body["meta"]["request_id"]) == 36
+
+    def test_health_meta_has_timestamp(self, client):
+        body = client.get("/health").json()
+        assert "timestamp" in body["meta"]
+        assert body["meta"]["timestamp"] != ""
+
+    def test_health_response_has_x_request_id_header(self, client):
+        resp = client.get("/health")
+        assert "x-request-id" in resp.headers
+
+    def test_health_x_request_id_matches_body(self, client):
+        resp = client.get("/health")
+        body = resp.json()
+        assert resp.headers["x-request-id"] == body["meta"]["request_id"]
+
+    def test_health_not_rate_limited(self, client):
+        """Health endpoint must never return 429 regardless of request count."""
+        for _ in range(20):
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+
+class TestReady:
+    def test_ready_returns_200(self, client):
+        resp = client.get("/ready")
+        assert resp.status_code == 200
+
+    def test_ready_envelope_shape(self, client):
+        body = client.get("/ready").json()
+        assert body["error"] is None
+        assert body["data"]["status"] == "ok"
+
+    def test_ready_x_request_id_header_present(self, client):
+        resp = client.get("/ready")
+        assert "x-request-id" in resp.headers
+
+
+class TestCustomRequestId:
+    def test_custom_request_id_is_echoed_in_header(self, client):
+        resp = client.get("/health", headers={"X-Request-ID": "my-trace-id-abc"})
+        assert resp.headers["x-request-id"] == "my-trace-id-abc"
+
+    def test_custom_request_id_is_in_body(self, client):
+        resp = client.get("/health", headers={"X-Request-ID": "my-trace-id-xyz"})
+        assert resp.json()["meta"]["request_id"] == "my-trace-id-xyz"
+
+    def test_each_request_gets_unique_id_when_none_provided(self, client):
+        ids = {client.get("/health").json()["meta"]["request_id"] for _ in range(5)}
+        assert len(ids) == 5

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -1,0 +1,168 @@
+import time
+import pytest
+import httpx
+
+
+class TestRateLimiting:
+    def test_health_never_rate_limited(self, client):
+        """Health endpoint is excluded from rate limiting."""
+        for _ in range(20):
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+    def test_ready_never_rate_limited(self, client):
+        """Ready endpoint is excluded from rate limiting."""
+        for _ in range(20):
+            resp = client.get("/ready")
+            assert resp.status_code == 200
+
+    def test_rate_limit_429_has_json_envelope(self, client):
+        """When rate limited, response must be a proper JSON envelope."""
+        import threading
+
+        responses = []
+        lock = threading.Lock()
+
+        def fire():
+            try:
+                r = httpx.get(
+                    f"{client.base_url}/v1/probe",
+                    timeout=5.0,
+                )
+                with lock:
+                    responses.append(r)
+            except Exception:
+                pass
+
+        threads = [threading.Thread(target=fire) for _ in range(120)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        limited = [r for r in responses if r.status_code == 429]
+        if not limited:
+            pytest.skip("Bucket not exhausted in this run - timing-dependent test")
+
+        resp = limited[0]
+        body = resp.json()
+        assert body["error"]["code"] == "TOO_MANY_REQUESTS"
+        assert body["data"] is None
+        assert "request_id" in body["meta"]
+
+    def test_rate_limit_429_has_retry_after_header(self, client):
+        """429 response must include Retry-After header."""
+        import threading
+
+        responses = []
+        lock = threading.Lock()
+
+        def fire():
+            try:
+                r = httpx.get(f"{client.base_url}/v1/probe", timeout=5.0)
+                with lock:
+                    responses.append(r)
+            except Exception:
+                pass
+
+        threads = [threading.Thread(target=fire) for _ in range(120)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        limited = [r for r in responses if r.status_code == 429]
+        if not limited:
+            pytest.skip("Bucket not exhausted in this run - timing-dependent test")
+
+        assert "retry-after" in limited[0].headers
+
+    def test_rate_limit_x_ratelimit_limit_header(self, client):
+        """429 response must include X-RateLimit-Limit header."""
+        import threading
+
+        responses = []
+        lock = threading.Lock()
+
+        def fire():
+            try:
+                r = httpx.get(f"{client.base_url}/v1/probe", timeout=5.0)
+                with lock:
+                    responses.append(r)
+            except Exception:
+                pass
+
+        threads = [threading.Thread(target=fire) for _ in range(120)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        limited = [r for r in responses if r.status_code == 429]
+        if not limited:
+            pytest.skip("Bucket not exhausted in this run - timing-dependent test")
+
+        assert "x-ratelimit-limit" in limited[0].headers
+
+
+class TestRequestSizeLimit:
+    def test_small_post_passes_through(self, client):
+        """POST under 1MiB passes size check."""
+        resp = client.post(
+            "/v1/anything",
+            content=b"x" * 100,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert resp.status_code in (401, 429)
+
+    def test_oversized_post_returns_413(self, client):
+        """POST body over 1MiB must return 413."""
+        resp = client.post(
+            "/v1/anything",
+            content=b"x" * (1024 * 1024 + 1),
+            headers={
+                "Content-Type": "application/octet-stream",
+                "Expect": "",
+            },
+        )
+        assert resp.status_code == 413
+
+    def test_oversized_post_error_code(self, client):
+        body = client.post(
+            "/v1/anything",
+            content=b"x" * (1024 * 1024 + 1),
+            headers={"Content-Type": "application/octet-stream", "Expect": ""},
+        ).json()
+        assert body["error"]["code"] == "PAYLOAD_TOO_LARGE"
+
+    def test_oversized_post_has_x_max_body_size_header(self, client):
+        resp = client.post(
+            "/v1/anything",
+            content=b"x" * (1024 * 1024 + 1),
+            headers={"Content-Type": "application/octet-stream", "Expect": ""},
+        )
+        assert "x-max-body-size" in resp.headers
+
+    def test_oversized_post_413_has_request_id(self, client):
+        resp = client.post(
+            "/v1/anything",
+            content=b"x" * (1024 * 1024 + 1),
+            headers={"Content-Type": "application/octet-stream", "Expect": ""},
+        )
+        body = resp.json()
+        assert "request_id" in body["meta"]
+        assert len(body["meta"]["request_id"]) == 36
+
+    def test_get_not_size_checked(self, client):
+        """GET requests are never size-checked."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_exactly_at_limit_passes(self, client):
+        """Body of exactly 1MiB (not over) should pass."""
+        resp = client.post(
+            "/v1/anything",
+            content=b"x" * (1024 * 1024),
+            headers={"Content-Type": "application/octet-stream", "Expect": ""},
+        )
+        assert resp.status_code in (401, 429)


### PR DESCRIPTION
Closes CORV-20

- conftest.py: JWT signing fixture, Redis API key setup/teardown, server wait
- test_health.py: health/ready endpoints, request ID pass-through
- test_auth_jwt.py: missing/malformed/expired/wrong-alg/valid JWT
- test_auth_api_key.py: missing/invalid/valid/revoked API keys via Redis
- test_middleware.py: rate limiting (429 + headers), request size limit (413)
- test_envelope.py: consistent JSON envelope shape across 401/404/413
- Fix: add X-Request-ID header to JWT and API key 401 responses
- Fix: restore catchall route registrations in router.cpp for preHandlingAdvice
- Fix: expose Redis port 6380 in docker-compose.override.yml