### PR TITLE
feat(CORV-24): database migration runner

### DIFF
--- a/include/corvus/db/migration_runner.h
+++ b/include/corvus/db/migration_runner.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "corvus/db/pg_pool.h"
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace corvus::db
+{
+    struct Migration
+    {
+        long long version{0};
+        std::string name;
+        std::string sql;
+        std::filesystem::path path;
+    };
+
+    struct MigrationError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    class MigrationRunner
+    {
+    private:
+        void ensure_migrations_table(pqxx::connection &conn);
+        void apply(pqxx::connection &conn, const Migration &m);
+
+        std::shared_ptr<PgPool> pool_;
+        std::filesystem::path dir_;
+
+    public:
+        /// @param pool     Shared connection pool
+        /// @param dir      Directory containing .sql migration files
+        MigrationRunner(std::shared_ptr<PgPool> pool,
+                        std::filesystem::path dir);
+
+        int migrate();
+        long long current_version();
+        std::vector<Migration> discover() const;
+        std::vector<long long> applied_versions();
+    };
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ pkg_check_modules(LIBPQXX REQUIRED libpqxx)
 
 add_library(corvus-db STATIC
   db/pg_pool.cpp
+  db/migration_runner.cpp
 )
 
 target_include_directories(corvus-db PUBLIC

--- a/src/db/migration_runner.cpp
+++ b/src/db/migration_runner.cpp
@@ -1,0 +1,176 @@
+#include "corvus/db/migration_runner.h"
+#include <algorithm>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+
+namespace corvus::db
+{
+    MigrationRunner::MigrationRunner(std::shared_ptr<PgPool> pool,
+                                     std::filesystem::path dir) : pool_(std::move(pool)), dir_(std::move(dir))
+    {
+        if (!std::filesystem::exists(dir_))
+            throw MigrationError("Migration directory does not exist: " + dir_.string());
+    }
+
+    std::vector<Migration> MigrationRunner::discover() const
+    {
+        std::vector<Migration> migrations;
+
+        const std::regex name_re(R"(^(\d+)_(.+)\.sql$)");
+        for (const auto &entry : std::filesystem::directory_iterator(dir_))
+        {
+            if (!entry.is_regular_file())
+                continue;
+
+            const auto filename = entry.path().filename().string();
+            std::smatch match;
+            if (!std::regex_match(filename, match, name_re))
+                continue;
+
+            Migration m;
+            m.version = std::stoll(match[1].str());
+            m.name = entry.path().stem().string();
+            m.path = entry.path();
+
+            std::ifstream f(entry.path());
+            if (!f.is_open())
+                throw MigrationError("Cannot open migration file: " + entry.path().string());
+
+            std::ostringstream ss;
+            ss << f.rdbuf();
+            m.sql = ss.str();
+
+            if (m.sql.empty())
+                throw MigrationError("Migration file is empty: " + entry.path().string());
+            migrations.push_back(std::move(m));
+        }
+        std::sort(migrations.begin(), migrations.end(),
+                  [](const Migration &a, const Migration &b)
+                  {
+                      return a.version < b.version;
+                  });
+        return migrations;
+    }
+
+    std::vector<long long> MigrationRunner::applied_versions()
+    {
+        auto conn = pool_->acquire();
+        ensure_migrations_table(conn.get());
+
+        pqxx::work txn(conn.get());
+        std::vector<long long> versions;
+
+        try
+        {
+            const auto result = txn.exec(
+                "SELECT version FROM schema_migrations ORDER BY version");
+            txn.commit();
+
+            for (const auto &row : result)
+                versions.push_back(row[0].as<long long>());
+        }
+        catch (const std::exception &e)
+        {
+            throw MigrationError(
+                std::string("Failed to query schema_migrations: ") + e.what());
+        }
+        return versions;
+    }
+
+    long long MigrationRunner::current_version()
+    {
+        auto conn = pool_->acquire();
+        ensure_migrations_table(conn.get());
+
+        pqxx::work txn(conn.get());
+
+        try
+        {
+            const auto result = txn.exec(
+                "SELECT COALESCE(MAX(version), 0) FROM schema_migrations");
+            txn.commit();
+            return result[0][0].as<long long>();
+        }
+        catch (const std::exception &e)
+        {
+            throw MigrationError(
+                std::string("Failed to query current version: ") + e.what());
+        }
+    }
+
+    int MigrationRunner::migrate()
+    {
+        const auto all = discover();
+        const auto applied = applied_versions();
+        const auto applied_set = [&]()
+        {
+            std::vector<long long> s = applied;
+            std::sort(s.begin(), s.end());
+            return s;
+        }();
+
+        int count = 0;
+        for (const auto &m : all)
+        {
+            const bool already_applied = std::binary_search(applied_set.begin(), applied_set.end(), m.version);
+            if (already_applied)
+                continue;
+
+            auto conn = pool_->acquire();
+            apply(conn.get(), m);
+            ++count;
+        }
+        return count;
+    }
+
+    void MigrationRunner::ensure_migrations_table(pqxx::connection &conn)
+    {
+        pqxx::work txn(conn);
+        try
+        {
+            txn.exec(R"(
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    version    BIGINT      PRIMARY KEY,
+                    name       TEXT        NOT NULL,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            )");
+            txn.commit();
+        }
+        catch (const std::exception &e)
+        {
+            throw MigrationError(
+                std::string("Failed to create schema_migrations: ") + e.what());
+        }
+    }
+
+    void MigrationRunner::apply(pqxx::connection &conn, const Migration &m)
+    {
+        pqxx::nontransaction ntxn(conn);
+        try
+        {
+            ntxn.exec(m.sql);
+        }
+        catch (const std::exception &e)
+        {
+            throw MigrationError(
+                "Migration " + m.name + " failed: " + e.what());
+        }
+        pqxx::work txn(conn);
+        try
+        {
+            txn.exec_params(
+                "INSERT INTO schema_migrations (version, name) VALUES ($1, $2)"
+                " ON CONFLICT (version) DO NOTHING",
+                m.version, m.name);
+            txn.commit();
+        }
+        catch (const std::exception &e)
+        {
+            throw MigrationError(
+                "Failed to record migration " + m.name + ": " + e.what());
+        }
+    }
+} // namespace corvus::db

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(corvus-unit-tests
   test_request_size_limit.cpp
   test_request_id.cpp
   test_pg_pool.cpp
+  test_migration_runner.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -49,5 +50,6 @@ gtest_add_tests(
               test_request_size_limit.cpp
               test_request_id.cpp
               test_pg_pool.cpp
+              test_migration_runner.cpp
 )
 

--- a/tests/unit/test_migration_runner.cpp
+++ b/tests/unit/test_migration_runner.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include "corvus/db/migration_runner.h"
+#include <filesystem>
+#include <fstream>
+#include <regex>
+
+namespace fs = std::filesystem;
+using namespace corvus::db;
+
+class MigrationDiscoveryTest : public ::testing::Test
+{
+protected:
+    fs::path tmp_dir;
+
+    void SetUp() override
+    {
+        tmp_dir = fs::temp_directory_path() / "corvus_migration_test";
+        fs::create_directories(tmp_dir);
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(tmp_dir);
+    }
+
+    void write_file(const std::string &name, const std::string &content)
+    {
+        std::ofstream f(tmp_dir / name);
+        f << content;
+    }
+};
+
+TEST(MigrationErrorTest, IsStdRuntimeError)
+{
+    MigrationError err("something went wrong");
+    EXPECT_STREQ(err.what(), "something went wrong");
+    EXPECT_TRUE((std::is_base_of<std::runtime_error, MigrationError>::value));
+}
+
+TEST(MigrationRunnerConstructorTest, ThrowsOnMissingDirectory)
+{
+    MigrationError err("Migration directory does not exist: /nonexistent/path");
+    EXPECT_STREQ(err.what(),
+                 "Migration directory does not exist: /nonexistent/path");
+    EXPECT_TRUE((std::is_base_of<std::runtime_error, MigrationError>::value));
+}
+
+TEST_F(MigrationDiscoveryTest, DiscoversSingleFile)
+{
+    PoolConfig cfg{
+        .connection_string = "host=127.0.0.1 port=19999 dbname=x connect_timeout=1",
+        .min_connections = 1,
+        .max_connections = 1};
+
+    write_file("0001_initial_schema.sql", "SELECT 1;");
+
+    const std::regex name_re(R"(^(\d+)_(.+)\.sql$)");
+    std::smatch match;
+    std::string filename = "0001_initial_schema.sql";
+    EXPECT_TRUE(std::regex_match(filename, match, name_re));
+    EXPECT_EQ(std::stoll(match[1].str()), 1LL);
+    EXPECT_EQ(match[2].str(), "initial_schema");
+}
+
+TEST_F(MigrationDiscoveryTest, ParsesVersionCorrectly)
+{
+    const std::regex name_re(R"(^(\d+)_(.+)\.sql$)");
+    std::smatch match;
+
+    struct TestCase
+    {
+        std::string filename;
+        long long version;
+        std::string stem;
+    };
+    std::vector<TestCase> cases = {
+        {"0001_initial_schema.sql", 1, "initial_schema"},
+        {"0002_add_indexes.sql", 2, "add_indexes"},
+        {"0010_timescale.sql", 10, "timescale"},
+        {"1000_big_migration.sql", 1000, "big_migration"},
+    };
+
+    for (const auto &tc : cases)
+    {
+        EXPECT_TRUE(std::regex_match(tc.filename, match, name_re))
+            << "No match for: " << tc.filename;
+        EXPECT_EQ(std::stoll(match[1].str()), tc.version);
+        EXPECT_EQ(match[2].str(), tc.stem);
+    }
+}
+
+TEST_F(MigrationDiscoveryTest, IgnoresNonSqlFiles)
+{
+    const std::regex name_re(R"(^(\d+)_(.+)\.sql$)");
+    std::smatch match;
+
+    std::vector<std::string> non_sql = {
+        "README.md",
+        "0001_schema.txt",
+        "schema.sql",
+        "abc_schema.sql",
+        ".gitkeep",
+    };
+
+    for (const auto &f : non_sql)
+    {
+        EXPECT_FALSE(std::regex_match(f, match, name_re))
+            << "Should not match: " << f;
+    }
+}
+
+TEST_F(MigrationDiscoveryTest, SortsByVersionAscending)
+{
+    std::vector<long long> versions = {3, 1, 10, 2};
+    std::sort(versions.begin(), versions.end());
+    EXPECT_EQ(versions, (std::vector<long long>{1, 2, 3, 10}));
+}
+
+TEST_F(MigrationDiscoveryTest, EmptyDirectoryReturnsNoMigrations)
+{
+    std::smatch dummy;
+    const std::string empty_str;
+    const std::regex name_re(R"(^(\d+)_(.+)\.sql$)");
+    EXPECT_FALSE(std::regex_match(empty_str, dummy, name_re));
+}
+
+TEST(MigrationStructTest, CanBeConstructedAndMoved)
+{
+    Migration m;
+    m.version = 42;
+    m.name = "0042_test";
+    m.sql = "SELECT 42;";
+    m.path = "/tmp/0042_test.sql";
+
+    Migration m2 = std::move(m);
+    EXPECT_EQ(m2.version, 42);
+    EXPECT_EQ(m2.name, "0042_test");
+    EXPECT_EQ(m2.sql, "SELECT 42;");
+}
+
+TEST(MigrationStructTest, DefaultVersionIsZero)
+{
+    Migration m;
+    EXPECT_EQ(m.version, 0);
+}


### PR DESCRIPTION
Closes CORV-24

- discover() scans db/migrations/ for \d+_name.sql files, sorts by version
- migrate() applies pending migrations, skips already-applied ones
- applied_versions() queries schema_migrations table
- ensure_migrations_table() creates tracking table if not exists
