### PR TITLE
feat(CORV-25): hiredis connection wrapper

### DIFF
--- a/include/corvus/db/redis_connection.h
+++ b/include/corvus/db/redis_connection.h
@@ -1,0 +1,120 @@
+#pragma once
+#include <hiredis/hiredis.h>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace corvus::db
+{
+
+    struct RedisConfigError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    struct RedisCommandError : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    struct RedisConfig
+    {
+        std::string host{"localhost"};
+        int port{6379};
+        int connect_timeout_ms{3000};
+        int command_timeout_ms{1000};
+        std::string password;
+        int db{0};
+    };
+
+    class RedisReply
+    {
+    public:
+        explicit RedisReply(redisReply *reply) : reply_(reply) {}
+        ~RedisReply()
+        {
+            if (reply_)
+                freeReplyObject(reply_);
+        }
+
+        redisReply *get() const noexcept { return reply_; }
+        redisReply *operator->() const noexcept { return reply_; }
+        explicit operator bool() const noexcept { return reply_ != nullptr; }
+
+        bool is_nil() const noexcept { return !reply_ || reply_->type == REDIS_REPLY_NIL; }
+        bool is_string() const noexcept { return !reply_ || reply_->type == REDIS_REPLY_STRING; }
+        bool is_status() const noexcept { return !reply_ || reply_->type == REDIS_REPLY_STATUS; }
+        bool is_integer() const noexcept { return !reply_ || reply_->type == REDIS_REPLY_INTEGER; }
+        bool is_array() const noexcept { return !reply_ || reply_->type == REDIS_REPLY_ARRAY; }
+        bool is_error() const noexcept { return !reply_ || reply_->type == REDIS_REPLY_ERROR; }
+
+        std::string str() const;
+        long long integer() const;
+
+        RedisReply(const RedisReply &) = delete;
+        RedisReply &operator=(const RedisReply &) = delete;
+
+    private:
+        redisReply *reply_;
+    };
+
+    class RedisConnection
+    {
+    public:
+        explicit RedisConnection(const RedisConfig &config);
+        ~RedisConnection();
+
+        RedisConnection(const RedisConnection &) = delete;
+        RedisConnection &operator=(const RedisConnection &) = delete;
+        RedisConnection(RedisConnection &&other) noexcept;
+        RedisConnection &operator=(RedisConnection &&other) noexcept;
+
+        bool is_connected() const noexcept;
+
+        void reconnect();
+
+        void set(const std::string &key, const std::string &value,
+                 int ttl_seconds = 0);
+
+        std::string get(const std::string &key);
+
+        long long del(const std::string &key);
+
+        long long exists(const std::string &key);
+
+        void expire(const std::string &key, int seconds);
+
+        void hset(const std::string &key, const std::string &field,
+                  const std::string &value);
+
+        std::string hget(const std::string &key, const std::string &field);
+
+        std::unordered_map<std::string, std::string>
+        hgetall(const std::string &key);
+
+        void hmset(const std::string &key,
+                   const std::unordered_map<std::string, std::string> &fields);
+
+        long long hdel(const std::string &key, const std::string &field);
+
+        bool ping();
+
+        const RedisConfig &config() const noexcept { return config_; }
+
+    private:
+        RedisReply command(const char *fmt, ...);
+        void check_connection();
+        void apply_timeouts();
+        void authenticate();
+        void select_db();
+
+        redisContext *ctx_{nullptr};
+        RedisConfig config_;
+    };
+
+    RedisConfig redis_config_from_env();
+} // namespace::db

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ pkg_check_modules(LIBPQXX REQUIRED libpqxx)
 add_library(corvus-db STATIC
   db/pg_pool.cpp
   db/migration_runner.cpp
+  db/redis_connection.cpp
 )
 
 target_include_directories(corvus-db PUBLIC
@@ -49,6 +50,7 @@ target_include_directories(corvus-db PUBLIC
 
 target_link_libraries(corvus-db PUBLIC
   ${LIBPQXX_LIBRARIES}
+  hiredis::hiredis
 )
 
 target_compile_features(corvus-db PUBLIC cxx_std_20)

--- a/src/db/redis_connection.cpp
+++ b/src/db/redis_connection.cpp
@@ -1,0 +1,364 @@
+#include "corvus/db/redis_connection.h"
+#include <cstdarg>
+#include <cstdlib>
+#include <stdexcept>
+
+namespace corvus::db
+{
+
+    std::string RedisReply::str() const
+    {
+        if (!reply_ || reply_->type == REDIS_REPLY_NIL)
+            return "";
+        if (reply_->type != REDIS_REPLY_STRING &&
+            reply_->type != REDIS_REPLY_STATUS)
+            throw RedisCommandError("Reply is not a string");
+        return std::string(reply_->str, reply_->len);
+    }
+
+    long long RedisReply::integer() const
+    {
+        if (!reply_ || reply_->type != REDIS_REPLY_INTEGER)
+            throw RedisCommandError("Reply is not an integer");
+        return reply_->integer;
+    }
+
+    RedisConnection::RedisConnection(const RedisConfig &config) : config_(config)
+    {
+        reconnect();
+    }
+
+    RedisConnection::~RedisConnection()
+    {
+        if (ctx_)
+        {
+            redisFree(ctx_);
+            ctx_ = nullptr;
+        }
+    }
+
+    RedisConnection::RedisConnection(RedisConnection &&other) noexcept
+        : ctx_(other.ctx_), config_(std::move(other.config_))
+    {
+        other.ctx_ = nullptr;
+    }
+
+    RedisConnection &RedisConnection::operator=(RedisConnection &&other) noexcept
+    {
+        if (this != &other)
+        {
+            if (ctx_)
+            {
+                redisFree(ctx_);
+            }
+            ctx_ = other.ctx_;
+            config_ = std::move(other.config_);
+            other.ctx_ = nullptr;
+        }
+        return *this;
+    }
+
+    bool RedisConnection::is_connected() const noexcept
+    {
+        return ctx_ != nullptr && ctx_->err == 0;
+    }
+
+    void RedisConnection::reconnect()
+    {
+        if (ctx_)
+        {
+            redisFree(ctx_);
+            ctx_ = nullptr;
+        }
+
+        struct timeval tv;
+        tv.tv_sec = config_.connect_timeout_ms / 1000;
+        tv.tv_usec = (config_.connect_timeout_ms % 1000) * 1000;
+
+        ctx_ = redisConnectWithTimeout(
+            config_.host.c_str(), config_.port, tv);
+
+        if (!ctx_)
+            throw RedisConfigError(
+                "Failed to allocate Redis context for " +
+                config_.host + ":" + std::to_string(config_.port));
+
+        if (ctx_->err)
+        {
+            std::string msg = "Redis connection failed to" +
+                              config_.host + ":" +
+                              std::to_string(config_.port) + ": " +
+                              ctx_->errstr;
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            throw RedisConfigError(msg);
+        }
+
+        apply_timeouts();
+        authenticate();
+        select_db();
+    }
+    void RedisConnection::apply_timeouts()
+    {
+        struct timeval tv;
+        tv.tv_sec = config_.command_timeout_ms / 1000;
+        tv.tv_usec = (config_.command_timeout_ms % 1000) * 1000;
+
+        redisSetTimeout(ctx_, tv);
+    }
+
+    void RedisConnection::authenticate()
+    {
+        if (config_.password.empty())
+            return;
+
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "AUTH %s", config_.password.c_str()));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisConfigError(
+                "Redis AUTH failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+    }
+
+    void RedisConnection::select_db()
+    {
+        if (config_.db == 0)
+            return;
+
+        auto *r = static_cast<redisReply *>(redisCommand(ctx_, "SELECT %d", config_.db));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisConfigError(
+                "Redis SELECT " + std::to_string(config_.db) + " failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+    }
+
+    void RedisConnection::check_connection()
+    {
+        if (!is_connected())
+            throw RedisCommandError("Redis conneciton is not open");
+    }
+
+    bool RedisConnection::ping()
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(redisCommand(ctx_, "PING"));
+        RedisReply reply(r);
+        return reply && reply.is_status() &&
+               std::string(reply->str) == "PONG";
+    }
+
+    void RedisConnection::set(const std::string &key, const std::string &value, int ttl_seconds)
+    {
+        check_connection();
+        redisReply *r;
+        if (ttl_seconds > 0)
+        {
+            r = static_cast<redisReply *>(
+                redisCommand(ctx_, "SET %s %b EX %d",
+                             key.c_str(),
+                             value.data(), value.size(),
+                             ttl_seconds));
+        }
+        else
+        {
+            r = static_cast<redisReply *>(
+                redisCommand(ctx_, "SET %s %b",
+                             key.c_str(),
+                             value.data(), value.size()));
+        }
+        RedisReply reply(r);
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "SET failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+    }
+
+    std::string RedisConnection::get(const std::string &key)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "GET %s", key.c_str()));
+        RedisReply reply(r);
+
+        if (!reply)
+            throw RedisCommandError("GET returned null reply");
+        if (reply.is_error())
+            throw RedisCommandError("GET failed: " + std::string(reply->str));
+        if (reply.is_nil())
+            return "";
+
+        return reply.str();
+    }
+
+    long long RedisConnection::del(const std::string &key)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "DEL %s", key.c_str()));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "DEL failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+        return reply.integer();
+    }
+
+    long long RedisConnection::exists(const std::string &key)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "EXISTS %s", key.c_str()));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "EXISTS failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+        return reply.integer();
+    }
+
+    void RedisConnection::expire(const std::string &key, int seconds)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "EXPIRE %s %d", key.c_str(), seconds));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "EXPIRE failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+    }
+
+    void RedisConnection::hset(const std::string &key,
+                               const std::string &field,
+                               const std::string &value)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "HSET %s %s %b",
+                         key.c_str(), field.c_str(),
+                         value.data(), value.size()));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "HSET failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+    }
+
+    std::string RedisConnection::hget(const std::string &key, const std::string &field)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "HGET %s %s", key.c_str(), field.c_str()));
+        RedisReply reply(r);
+
+        if (!reply)
+            throw RedisCommandError("HGET returned null reply");
+        if (reply.is_error())
+            throw RedisCommandError("HGET failed: " + std::string(reply->str));
+        if (reply.is_nil())
+            return "";
+
+        return reply.str();
+    }
+
+    std::unordered_map<std::string, std::string>
+    RedisConnection::hgetall(const std::string &key)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "HGETALL %s", key.c_str()));
+        RedisReply reply(r);
+
+        if (!reply)
+            throw RedisCommandError("HGETALL returned null reply");
+        if (reply.is_error())
+            throw RedisCommandError("HGETALL failed: " + std::string(reply->str));
+        if (reply.is_nil())
+            return {};
+
+        std::unordered_map<std::string, std::string> result;
+        for (size_t i = 0; i < reply->elements; i += 2)
+        {
+            result[reply->element[i]->str] =
+                reply->element[i + 1]->str;
+        }
+        return result;
+    }
+
+    void RedisConnection::hmset(
+        const std::string &key,
+        const std::unordered_map<std::string, std::string> &fields)
+    {
+        if (fields.empty())
+            return;
+        check_connection();
+
+        std::vector<const char *> argv;
+        std::vector<std::size_t> argvlen;
+
+        argv.push_back("HMSET");
+        argvlen.push_back(5);
+        argv.push_back(key.c_str());
+        argvlen.push_back(key.size());
+
+        for (const auto &[f, v] : fields)
+        {
+            argv.push_back(f.c_str());
+            argvlen.push_back(f.size());
+            argv.push_back(v.c_str());
+            argvlen.push_back(v.size());
+        }
+
+        auto *r = static_cast<redisReply *>(
+            redisCommandArgv(ctx_,
+                             static_cast<int>(argv.size()),
+                             argv.data(),
+                             argvlen.data()));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "HMSET failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+    }
+
+    long long RedisConnection::hdel(const std::string &key,
+                                    const std::string &field)
+    {
+        check_connection();
+        auto *r = static_cast<redisReply *>(
+            redisCommand(ctx_, "HDEL %s %s", key.c_str(), field.c_str()));
+        RedisReply reply(r);
+
+        if (!reply || reply.is_error())
+            throw RedisCommandError(
+                "HDEL failed: " +
+                (reply ? std::string(reply->str) : "null reply"));
+        return reply.integer();
+    }
+
+    RedisConfig redis_config_from_env()
+    {
+        auto get = [](const char *var, const char *fb) -> std::string
+        {
+            const char *val = std::getenv(var);
+            return (val && *val) ? val : fb;
+        };
+
+        RedisConfig cfg;
+        cfg.host = get("CORVUS_REDIS_HOST", "localhost");
+        cfg.port = std::stoi(get("CORVUS_REDIS_PORT", "6379"));
+        cfg.password = get("CORVUS_REDIS_PASSWORD", "");
+        cfg.db = std::stoi(get("CORVUS_REDIS_DB", "0"));
+        return cfg;
+    }
+
+} // namespace corvus::db

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(corvus-unit-tests
   test_request_id.cpp
   test_pg_pool.cpp
   test_migration_runner.cpp
+  test_redis_connection.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -51,5 +52,6 @@ gtest_add_tests(
               test_request_id.cpp
               test_pg_pool.cpp
               test_migration_runner.cpp
+              test_redis_connection.cpp
 )
 

--- a/tests/unit/test_redis_connection.cpp
+++ b/tests/unit/test_redis_connection.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include "corvus/db/redis_connection.h"
+#include <cstdlib>
+
+using namespace corvus::db;
+
+TEST(RedisConfigErrorTest, IsStdRuntimeError)
+{
+    RedisConfigError err("bad config");
+    EXPECT_STREQ(err.what(), "bad config");
+    EXPECT_TRUE((std::is_base_of<std::runtime_error, RedisConfigError>::value));
+}
+
+TEST(RedisCommandErrorTest, IsStdRuntimeError)
+{
+    RedisCommandError err("command failed");
+    EXPECT_STREQ(err.what(), "command failed");
+    EXPECT_TRUE((std::is_base_of<std::runtime_error, RedisCommandError>::value));
+}
+
+TEST(RedisConfigTest, DefaultHostIsLocalhost)
+{
+    RedisConfig cfg;
+    EXPECT_EQ(cfg.host, "localhost");
+}
+
+TEST(RedisConfigTest, DefaultPortIs6379)
+{
+    RedisConfig cfg;
+    EXPECT_EQ(cfg.port, 6379);
+}
+
+TEST(RedisConfigTest, DefaultDbIsZero)
+{
+    RedisConfig cfg;
+    EXPECT_EQ(cfg.db, 0);
+}
+
+TEST(RedisConfigTest, DefaultPasswordIsEmpty)
+{
+    RedisConfig cfg;
+    EXPECT_TRUE(cfg.password.empty());
+}
+
+TEST(RedisConfigTest, DefaultConnectTimeoutIs3000ms)
+{
+    RedisConfig cfg;
+    EXPECT_EQ(cfg.connect_timeout_ms, 3000);
+}
+
+TEST(RedisConfigTest, DefaultCommandTimeoutIs1000ms)
+{
+    RedisConfig cfg;
+    EXPECT_EQ(cfg.command_timeout_ms, 1000);
+}
+
+TEST(RedisConnectionTest, ThrowsOnUnreachableHost)
+{
+    RedisConfig cfg;
+    cfg.host = "127.0.0.1";
+    cfg.port = 19999;
+    cfg.connect_timeout_ms = 100;
+
+    EXPECT_THROW(RedisConnection conn(cfg), RedisConfigError);
+}
+
+TEST(RedisReplyTest, NullReplyIsFalsy)
+{
+    RedisReply reply(nullptr);
+    EXPECT_FALSE(static_cast<bool>(reply));
+    EXPECT_TRUE(reply.is_nil());
+}
+
+TEST(RedisReplyTest, TypeConstantsHaveExpectedValues)
+{
+    EXPECT_EQ(REDIS_REPLY_STRING, 1);
+    EXPECT_EQ(REDIS_REPLY_ARRAY, 2);
+    EXPECT_EQ(REDIS_REPLY_INTEGER, 3);
+    EXPECT_EQ(REDIS_REPLY_NIL, 4);
+    EXPECT_EQ(REDIS_REPLY_STATUS, 5);
+    EXPECT_EQ(REDIS_REPLY_ERROR, 6);
+}
+
+TEST(RedisConfigFromEnvTest, ReadsHostFromEnv)
+{
+    setenv("CORVUS_REDIS_HOST", "myredis", 1);
+    const auto cfg = redis_config_from_env();
+    unsetenv("CORVUS_REDIS_HOST");
+    EXPECT_EQ(cfg.host, "myredis");
+}
+
+TEST(RedisConfigFromEnvTest, ReadsPortFromEnv)
+{
+    setenv("CORVUS_REDIS_PORT", "6380", 1);
+    const auto cfg = redis_config_from_env();
+    unsetenv("CORVUS_REDIS_PORT");
+    EXPECT_EQ(cfg.port, 6380);
+}
+
+TEST(RedisConfigFromEnvTest, ReadsDbFromEnv)
+{
+    setenv("CORVUS_REDIS_DB", "2", 1);
+    const auto cfg = redis_config_from_env();
+    unsetenv("CORVUS_REDIS_DB");
+    EXPECT_EQ(cfg.db, 2);
+}
+
+TEST(RedisConfigFromEnvTest, DefaultsWhenEnvNotSet)
+{
+    unsetenv("CORVUS_REDIS_HOST");
+    unsetenv("CORVUS_REDIS_PORT");
+    unsetenv("CORVUS_REDIS_DB");
+
+    const auto cfg = redis_config_from_env();
+    EXPECT_EQ(cfg.host, "localhost");
+    EXPECT_EQ(cfg.port, 6379);
+    EXPECT_EQ(cfg.db, 0);
+}


### PR DESCRIPTION
Closes CORV-25

- RedisReply RAII wrapper
- RedisConnection RAII wrapper
- Commands: SET/GET, DEL, EXISTS, EXPIRE, HSET/HGET/HGETALL/HMSET/HDEL, PING
- Timeout applied via redisSetTimeout after connect
- AUTH and SELECT called automatically if configured
- redis_config_from_env() reads CORVUS_REDIS_* env vars
- 15 unit tests: error types, config defaults, unreachable host, env parsing
- Live smoke test: PING, SET/GET, HSET/HGET, HGETALL, DEL/EXISTS all passing