### PR TITLE
feat(CORV-26): cache-aside pattern helper

### DIFF
--- a/include/corvus/db/cache_aside.h
+++ b/include/corvus/db/cache_aside.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "corvus/db/redis_connection.h"
+#include <chrono>
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace corvus::db
+{
+    struct CacheConfig
+    {
+        int default_ttl_seconds{300};
+        std::string key_prefix{"corvus:"};
+    };
+
+    class CacheAside
+    {
+    public:
+        using FetchFn = std::function<std::optional<std::string>()>;
+
+        explicit CacheAside(RedisConnection &redis,
+                            CacheConfig config = {});
+
+        std::optional<std::string> get_or_fetch(const std::string &key,
+                                                FetchFn fetch,
+                                                int ttl_seconds = -1);
+
+        std::optional<std::string> get(const std::string &key);
+
+        void put(const std::string &key, const std::string &value, int ttl_seconds = -1);
+
+        void invalidate(const std::string &key);
+
+        void invalidate_prefix(const std::string &prefix);
+
+        bool exists(const std::string &key);
+
+        const CacheConfig &config() const noexcept { return config_; }
+
+        std::string make_key(const std::string &key) const;
+
+    private:
+        int effective_ttl(int ttl_seconds) const noexcept
+        {
+            return (ttl_seconds < 0) ? config_.default_ttl_seconds : ttl_seconds;
+        }
+
+        RedisConnection &redis_;
+        CacheConfig config_;
+    };
+
+} // namespace corvus::db

--- a/include/corvus/db/redis_connection.h
+++ b/include/corvus/db/redis_connection.h
@@ -105,6 +105,8 @@ namespace corvus::db
 
         const RedisConfig &config() const noexcept { return config_; }
 
+        redisContext *ctx() noexcept { return ctx_; }
+
     private:
         RedisReply command(const char *fmt, ...);
         void check_connection();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(corvus-db STATIC
   db/pg_pool.cpp
   db/migration_runner.cpp
   db/redis_connection.cpp
+  db/cache_aside.cpp
 )
 
 target_include_directories(corvus-db PUBLIC

--- a/src/db/cache_aside.cpp
+++ b/src/db/cache_aside.cpp
@@ -1,0 +1,89 @@
+#include "corvus/db/cache_aside.h"
+#include <hiredis/hiredis.h>
+
+namespace corvus::db
+{
+
+    CacheAside::CacheAside(RedisConnection &redis, CacheConfig config)
+        : redis_(redis), config_(std::move(config))
+    {
+    }
+
+    std::string CacheAside::make_key(const std::string &key) const
+    {
+        return config_.key_prefix + key;
+    }
+
+    std::optional<std::string> CacheAside::get(const std::string &key)
+    {
+        const auto full_key = make_key(key);
+        const auto value = redis_.get(full_key);
+
+        if (value.empty() && redis_.exists(full_key) == 0)
+            return std::nullopt;
+        return value;
+    }
+
+    void CacheAside::put(const std::string &key,
+                         const std::string &value,
+                         int ttl_seconds)
+    {
+        redis_.set(make_key(key), value, effective_ttl(ttl_seconds));
+    }
+
+    std::optional<std::string> CacheAside::get_or_fetch(
+        const std::string &key,
+        FetchFn fetch,
+        int ttl_seconds)
+    {
+        const auto full_key = make_key(key);
+        const auto cached = redis_.get(full_key);
+        if (!cached.empty() || redis_.exists(full_key) == 1)
+            return cached;
+
+        auto value = fetch();
+        if (!value.has_value())
+            return std::nullopt;
+
+        redis_.set(full_key, *value, effective_ttl(ttl_seconds));
+        return value;
+    }
+
+    void CacheAside::invalidate(const std::string &key)
+    {
+        redis_.del(make_key(key));
+    }
+
+    void CacheAside::invalidate_prefix(const std::string &prefix)
+    {
+        const auto pattern = make_key(prefix) + "*";
+
+        long long cursor = 0;
+        do
+        {
+            auto *r = static_cast<redisReply *>(
+                redisCommand(redis_.ctx(),
+                             "SCAN %lld MATCH %s COUNT 100",
+                             cursor, pattern.c_str()));
+            RedisReply reply(r);
+
+            if (!reply || !reply.is_array() || reply->elements < 2)
+                break;
+
+            cursor = std::stoll(reply->element[0]->str);
+
+            auto *keys = reply->element[1];
+            for (std::size_t i = 0; i < keys->elements; ++i)
+            {
+                if (keys->element[i]->str)
+                    redis_.del(keys->element[i]->str);
+            }
+        } while (cursor != 0);
+    }
+
+    bool CacheAside::exists(const std::string &key)
+    {
+        return redis_.exists(make_key(key)) == 1;
+    }
+
+} // namespace corvus::db

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(corvus-unit-tests
   test_pg_pool.cpp
   test_migration_runner.cpp
   test_redis_connection.cpp
+  test_cache_aside.cpp
 )
 
 target_include_directories(corvus-unit-tests PRIVATE
@@ -53,5 +54,6 @@ gtest_add_tests(
               test_pg_pool.cpp
               test_migration_runner.cpp
               test_redis_connection.cpp
+              test_cache_aside.cpp
 )
 

--- a/tests/unit/test_cache_aside.cpp
+++ b/tests/unit/test_cache_aside.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+#include "corvus/db/cache_aside.h"
+
+using namespace corvus::db;
+
+TEST(CacheConfigTest, DefaultTtlIs300Seconds)
+{
+    CacheConfig cfg;
+    EXPECT_EQ(cfg.default_ttl_seconds, 300);
+}
+
+TEST(CacheConfigTest, DefaultKeyPrefixIsCorvus)
+{
+    CacheConfig cfg;
+    EXPECT_EQ(cfg.key_prefix, "corvus:");
+}
+
+TEST(CacheConfigTest, CustomTtlIsRespected)
+{
+    CacheConfig cfg;
+    cfg.default_ttl_seconds = 60;
+    EXPECT_EQ(cfg.default_ttl_seconds, 60);
+}
+
+TEST(CacheConfigTest, CustomPrefixIsRespected)
+{
+    CacheConfig cfg;
+    cfg.key_prefix = "myapp:";
+    EXPECT_EQ(cfg.key_prefix, "myapp:");
+}
+
+TEST(CacheConfigTest, ZeroTtlMeansNoExpiry)
+{
+    CacheConfig cfg;
+    cfg.default_ttl_seconds = 0;
+    EXPECT_EQ(cfg.default_ttl_seconds, 0);
+}
+
+TEST(MakeKeyTest, PrependsPrefixToKey)
+{
+    const std::string prefix = "corvus:";
+    const std::string key = "clients:abc123";
+    EXPECT_EQ(prefix + key, "corvus:clients:abc123");
+}
+
+TEST(MakeKeyTest, EmptyPrefixReturnsKeyAsIs)
+{
+    const std::string prefix = "";
+    const std::string key = "mykey";
+    EXPECT_EQ(prefix + key, "mykey");
+}
+
+TEST(MakeKeyTest, NestedKeyBuildsCorrectly)
+{
+    const std::string prefix = "corvus:";
+    const std::string key = "resources:server:001";
+    EXPECT_EQ(prefix + key, "corvus:resources:server:001");
+}
+
+TEST(EffectiveTtlTest, NegativeUsesDefault)
+{
+    const int default_ttl = 300;
+    const int ttl_arg = -1;
+    const int result = (ttl_arg < 0) ? default_ttl : ttl_arg;
+    EXPECT_EQ(result, 300);
+}
+
+TEST(EffectiveTtlTest, ZeroOverridesDefault)
+{
+    const int default_ttl = 300;
+    const int ttl_arg = 0;
+    const int result = (ttl_arg < 0) ? default_ttl : ttl_arg;
+    EXPECT_EQ(result, 0);
+}
+
+TEST(EffectiveTtlTest, PositiveOverridesDefault)
+{
+    const int default_ttl = 300;
+    const int ttl_arg = 60;
+    const int result = (ttl_arg < 0) ? default_ttl : ttl_arg;
+    EXPECT_EQ(result, 60);
+}
+
+TEST(FetchFnTest, LambdaCanReturnValue)
+{
+    CacheAside::FetchFn fetch = []() -> std::optional<std::string>
+    {
+        return std::string("fetched_value");
+    };
+    auto result = fetch();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "fetched_value");
+}
+
+TEST(FetchFnTest, LambdaCanReturnNullopt)
+{
+    CacheAside::FetchFn fetch = []() -> std::optional<std::string>
+    {
+        return std::nullopt;
+    };
+    auto result = fetch();
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(FetchFnTest, LambdaCalledOnlyOnce)
+{
+    int call_count = 0;
+    CacheAside::FetchFn fetch = [&]() -> std::optional<std::string>
+    {
+        ++call_count;
+        return std::string("value");
+    };
+    fetch();
+    EXPECT_EQ(call_count, 1);
+}


### PR DESCRIPTION
Closes CORV-26

- get_or_fetch(key, fetch, ttl): Redis check → miss → fetch → populate → return
- put(key, value, ttl): write directly to cache
- get(key): read directly from cache, nullopt on miss
- invalidate(key): delete single cache entry
- invalidate_prefix(prefix): SCAN-based bulk delete by prefix pattern
- exists(key): check cache presence
- effective_ttl inline: per-call override or falls back to config default
- make_key: prepends config.key_prefix to all keys