### PR TITLE
feat(CORV-27): TimescaleDB for audit_log hypertable

### DIFF
--- a/db/migrations/0002_timescale_audit_hypertable.sql
+++ b/db/migrations/0002_timescale_audit_hypertable.sql
@@ -1,0 +1,23 @@
+BEGIN;
+-- 1. Enable the TimescaleDB extension
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+-- 2. Convert audit_log into a hypertable
+--    chunk_time_interval = 7 days -> roughly one chunk per week
+--    if_not_exists = TRUE makes the migration idempotent
+--    migrate_data = TRUE handles any rows that already exist
+SELECT create_hypertable(
+        'audit_log',
+        'occurred_at',
+        chunk_time_interval => INTERVAL '7 days',
+        if_not_exists => TRUE,
+        migrate_data => TRUE
+    );
+-- 3. Retention policy - drop chunks older than 90 days
+--    Re-running add_retention_policy with the same arguments is a no-op
+--    when if_not_exists = TRUE
+SELECT add_retention_policy(
+        'audit_log',
+        INTERVAL '90 days',
+        if_not_exists => TRUE
+    );
+COMMIT;

--- a/deploy/docker/init-timescale.sh
+++ b/deploy/docker/init-timescale.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Placeholder for TimescaleDB extension init.
-# In Epic 8 this will install the timescaledb extension and create the
-# audit_log hypertable. For now corvus_ts runs as plain PostgreSQL.
-echo "TimescaleDB init placeholder — Epic 8 will add extension setup"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,10 @@ services:
         reservations:
           memory: 32m
 
-  # PostgreSQL - alpine image, minimal config
+  # PostgreSQL with TimescaleDB extension
+  # used for both relational tables and the audit_log hypertable.
   postgres:
-    image: postgres:16-alpine
+    image: timescale/timescaledb:2.17.2-pg16
     environment:
       POSTGRES_DB: corvus
       POSTGRES_USER: corvus
@@ -63,7 +64,8 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF8"
     command: >
       postgres
-      -c shared_buffers=32MB
+      -c shared_preload_libraries=timescaledb
+      -c shared_buffers=64MB
       -c max_connections=20
       -c wal_level=minimal
       -c max_wal_senders=0
@@ -81,10 +83,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128m
+          memory: 256m
           cpus: "0.5"
         reservations:
-          memory: 32m
+          memory: 64m
 
   # Redis - alpine, AOF disabled for dev (faster, less disk)
   redis:
@@ -110,36 +112,6 @@ services:
         limits:
           memory: 96m
           cpus: "0.25"
-        reservations:
-          memory: 32m
-
-  # TimescaleDB - replaced with postgres + timescaledb extension
-  timescaledb:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: corvus_ts
-      POSTGRES_USER: corvus
-      POSTGRES_PASSWORD: ${TIMESCALE_PASSWORD:-corvus_dev}
-    command: >
-      postgres
-      -c shared_buffers=32MB
-      -c max_connections=10
-      -c synchronous_commit=off
-    volumes:
-      - ./deploy/docker/init-timescale.sh:/docker-entrypoint-initdb.d/init-timescale.sh:ro
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U corvus -d corvus_ts"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    networks:
-      - datastore
-    restart: on-failure
-    deploy:
-      resources:
-        limits:
-          memory: 128m
-          cpus: "0.5"
         reservations:
           memory: 32m
 


### PR DESCRIPTION
- Switch main postgres to timescale/timescaledb:2.17.2-pg16
- shared_preload_libraries=timescaledb in postgres command
- Remove redundant timescaledb service and init-timescale.sh placeholder
- Migration 0002: enable extension, convert audit_log to hypertable partitioned by occurred_at with 7-day chunks
- Add 90-day retention policy
- Composite PK (id, occurred_at) from 0001 makes hypertable conversion clean
- Single TimescaleDB-enabled DB preserves FK from audit_log.client_id -> clients.id