### PR TITLE
test(CORV-28): Database integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,6 @@ Full architecture documentation lives in [`docs/architecture/overview.md`](docs/
 | Security hardening       | Planned     |
 | Documentation + polish   | Planned     |
 
-### Epic 2 — API gateway + auth (complete)
-
-- JWT RS256 authentication middleware (`/v1/*` routes)
-- API key validation via Redis hash lookup
-- Token bucket rate limiting (100 req/burst, 10 req/s refill, per-IP)
-- Request size limit enforcement (1 MiB default, 413 JSON envelope)
-- Request ID middleware (UUID v4 injection, `X-Request-ID` echo)
-- Consistent JSON error envelope across all error conditions
-- 97 unit tests (C++ Google Test) + 72 integration tests (Python pytest)
-- ADR-0001 (language split), ADR-0002 (Drogon framework choice)
-
----
-
 ## Getting started
 
 ### Prerequisites
@@ -119,6 +106,7 @@ content = 'services:\n  corvus-core:\n    environment:\n      CORVUS_JWT_PUBLIC_
 for line in key.split('\n'):
     content += '        ' + line + '\n'
 content += '  redis:\n    ports:\n      - \"6380:6379\"\n'
+content += '  postgres:\n    ports:\n      - \"5433:5432\"\n'
 open('docker-compose.override.yml', 'w').write(content)
 "
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pydantic>=2.0
 PyJWT>=2.8
 cryptography>=42.0
 redis>=5.0
+psycopg2-binary>=2.9

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,11 @@ Requires:
   CORVUS_BASE_URL          - defaults to http://localhost:8080
   CORVUS_REDIS_HOST        - defaults to localhost
   CORVUS_REDIS_PORT        - defaults to 6379
+  CORVUS_DB_HOST           - defaults to localhost
+  CORVUS_DB_PORT           - defaults to 5433 (host-exposed Postgres)
+  CORVUS_DB_NAME           - defaults to corvus
+  CORVUS_DB_USER           - defaults to corvus
+  CORVUS_DB_PASSWORD       - defaults to corvus_dev
 """
 
 import os
@@ -15,6 +20,7 @@ import hashlib
 import pytest
 import httpx
 import redis as redis_client
+import psycopg2
 
 from datetime import datetime, timedelta, timezone
 
@@ -27,6 +33,12 @@ BASE_URL = os.environ.get("CORVUS_BASE_URL", "http://localhost:8080")
 REDIS_HOST = os.environ.get("CORVUS_REDIS_HOST", "localhost")
 REDIS_PORT = int(os.environ.get("CORVUS_REDIS_PORT", "6380"))
 PRIVATE_KEY = os.environ.get("CORVUS_TEST_PRIVATE_KEY", "")
+
+DB_HOST = os.environ.get("CORVUS_DB_HOST", "localhost")
+DB_PORT = int(os.environ.get("CORVUS_DB_PORT", "5433"))
+DB_NAME = os.environ.get("CORVUS_DB_NAME", "corvus")
+DB_USER = os.environ.get("CORVUS_DB_USER", "corvus")
+DB_PASSWORD = os.environ.get("CORVUS_DB_PASSWORD", "corvus_dev")
 
 
 def make_jwt(
@@ -86,6 +98,35 @@ def redis() -> redis_client.Redis:
     except Exception as e:
         pytest.skip(f"Redis not reachable at {REDIS_HOST}:{REDIS_PORT} - {e}")
     return r
+
+
+@pytest.fixture(scope="session")
+def pg_conn():
+    """Session-scoped PostgreSQL connection for integration tests."""
+
+    try:
+        conn = psycopg2.connect(
+            host=DB_HOST,
+            port=DB_PORT,
+            dbname=DB_NAME,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            connect_timeout=5,
+        )
+        conn.autocommit = True
+    except Exception as e:
+        pytest.skip(f"Postgres not reachable at {DB_HOST}:{DB_PORT} - {e}")
+        return
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def pg_cursor(pg_conn):
+    """ "Fresh cursor per test. Cleaned up on teardown."""
+    cur = pg_conn.cursor()
+    yield cur
+    cur.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_cache_aside.py
+++ b/tests/integration/test_cache_aside.py
@@ -1,0 +1,105 @@
+import time
+import uuid
+import pytest
+
+PREFIX = "corvus:test:"
+
+
+@pytest.fixture
+def cache_key():
+    """Unique cache key per test."""
+    return f"{PREFIX}{uuid.uuid4()}"
+
+
+@pytest.fixture
+def cleanup_cache_keys(redis):
+    """Delete any keys matching corvus:test:* after the test."""
+    yield
+    for key in redis.scan_iter(match=f"{PREFIX}*"):
+        redis.delete(key)
+
+
+def test_redis_set_and_get(redis, cache_key, cleanup_cache_keys):
+    redis.set(cache_key, "hello")
+    assert redis.get(cache_key) == "hello"
+
+
+def test_redis_get_missing_returns_none(redis):
+    assert redis.get(f"{PREFIX}does-not-exist") is None
+
+
+def test_set_with_ttl_persists_for_at_least_ttl(redis, cache_key, cleanup_cache_keys):
+    redis.set(cache_key, "ephemeral", ex=10)
+    ttl = redis.ttl(cache_key)
+    assert 0 < ttl <= 10
+
+
+def test_set_without_ttl_has_no_expiry(redis, cache_key, cleanup_cache_keys):
+    redis.set(cache_key, "permanent")
+    assert redis.ttl(cache_key) == -1
+
+
+def test_short_ttl_key_expires(redis, cache_key, cleanup_cache_keys):
+    redis.set(cache_key, "expires-fast", ex=1)
+    assert redis.get(cache_key) == "expires-fast"
+    time.sleep(1.5)
+    assert redis.get(cache_key) is None
+
+
+def test_exists_returns_one_for_present_key(redis, cache_key, cleanup_cache_keys):
+    redis.set(cache_key, "x")
+    assert redis.exists(cache_key) == 1
+
+
+def test_exists_returns_zero_for_missing_key(redis):
+    assert redis.exists(f"{PREFIX}missing-{uuid.uuid4()}") == 0
+
+
+def test_delete_removes_key(redis, cache_key, cleanup_cache_keys):
+    redis.set(cache_key, "delete-me")
+    assert redis.delete(cache_key) == 1
+    assert redis.exists(cache_key) == 0
+
+
+def test_delete_returns_zero_for_missing(redis):
+    assert redis.delete(f"{PREFIX}never-existed-{uuid.uuid4()}") == 0
+
+
+def test_scan_finds_keys_by_pattern(redis, cleanup_cache_keys):
+    scope = f"{PREFIX}scan-{uuid.uuid4()}-"
+    for i in range(5):
+        redis.set(f"{scope}{i}", str(i))
+
+    found = list(redis.scan_iter(match=f"{scope}*"))
+    assert len(found) == 5
+
+
+def test_scan_then_delete_invalidates_prefix(redis, cleanup_cache_keys):
+    scope = f"{PREFIX}bulk-{uuid.uuid4()}-"
+    for i in range(10):
+        redis.set(f"{scope}{i}", str(i))
+
+    for key in redis.scan_iter(match=f"{scope}*", count=100):
+        redis.delete(key)
+
+    found = list(redis.scan_iter(match=f"{scope}*"))
+    assert found == []
+
+
+def test_hset_and_hget(redis, cache_key, cleanup_cache_keys):
+    redis.hset(cache_key, "client_id", "client-abc")
+    redis.hset(cache_key, "scopes", "read,write")
+
+    assert redis.hget(cache_key, "client_id") == "client-abc"
+    assert redis.hget(cache_key, "scopes") == "read,write"
+
+
+def test_hgetall_returns_all_fields(redis, cache_key, cleanup_cache_keys):
+    redis.hset(cache_key, mapping={"a": "1", "b": "2", "c": "3"})
+    result = redis.hgetall(cache_key)
+    assert result == {"a": "1", "b": "2", "c": "3"}
+
+
+def test_hget_missing_field_returns_none(redis, cache_key, cleanup_cache_keys):
+    redis.hset(cache_key, "exists", "yes")
+    assert redis.hget(cache_key, "absent") is None

--- a/tests/integration/test_db_audit_log.py
+++ b/tests/integration/test_db_audit_log.py
@@ -1,0 +1,198 @@
+import time
+import uuid
+import pytest
+from datetime import datetime, timezone, timedelta
+
+
+@pytest.fixture
+def audit_request_id():
+    """Unique request_id prefix for each test, used for cleanup."""
+    rid = f"test-{uuid.uuid4()}"
+    yield rid
+
+
+@pytest.fixture
+def audit_cleanup(pg_conn, audit_request_id):
+    """Delete all audit_log rows for this test's request_id prefix."""
+    yield
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM audit_log WHERE request_id LIKE %s",
+            (f"{audit_request_id}%",),
+        )
+
+
+def insert_audit_row(
+    cursor,
+    request_id: str,
+    *,
+    occurred_at=None,
+    method: str = "GET",
+    path: str = "/v1/test",
+    status_code: int = 200,
+):
+    cursor.execute(
+        """
+        INSERT INTO audit_log
+            (occurred_at, request_id, method, path, status_code)
+        VALUES (%s, %s, %s, %s, %s)
+        RETURNING id, occurred_at
+        """,
+        (
+            occurred_at or datetime.now(timezone.utc),
+            request_id,
+            method,
+            path,
+            status_code,
+        ),
+    )
+    return cursor.fetchone()
+
+
+def test_audit_log_insert_and_read_back(pg_cursor, audit_request_id, audit_cleanup):
+    inserted_id, inserted_ts = insert_audit_row(pg_cursor, audit_request_id)
+
+    pg_cursor.execute(
+        "SELECT method, path, status_code FROM audit_log WHERE id = %s",
+        (inserted_id,),
+    )
+    row = pg_cursor.fetchone()
+    assert row == ("GET", "/v1/test", 200)
+
+
+def test_audit_log_default_occurred_at(pg_cursor, audit_request_id, audit_cleanup):
+    pg_cursor.execute(
+        """
+        INSERT INTO audit_log (request_id, method, path, status_code)
+        VALUES (%s, 'POST', '/v1/x', 201)
+        RETURNING occurred_at
+        """,
+        (audit_request_id,),
+    )
+    ts = pg_cursor.fetchone()[0]
+    now = datetime.now(timezone.utc)
+    assert abs((now - ts).total_seconds()) < 5
+
+
+def test_audit_log_metadata_is_jsonb(pg_cursor, audit_request_id, audit_cleanup):
+    pg_cursor.execute(
+        """
+        INSERT INTO audit_log
+            (request_id, method, path, status_code, metadata)
+        VALUES (%s, 'GET', '/v1/x', 200, %s::jsonb)
+        RETURNING id
+        """,
+        (audit_request_id, '{"foo": "bar", "n": 42}'),
+    )
+    row_id = pg_cursor.fetchone()[0]
+
+    pg_cursor.execute(
+        "SELECT metadata->>'foo', (metadata->>'n')::int FROM audit_log WHERE id = %s",
+        (row_id,),
+    )
+    assert pg_cursor.fetchone() == ("bar", 42)
+
+
+def test_audit_log_id_alone_not_unique(pg_cursor, audit_request_id, audit_cleanup):
+    shared_id = str(uuid.uuid4())
+    pg_cursor.execute(
+        """
+        INSERT INTO audit_log (id, occurred_at, request_id, method, path, status_code)
+        VALUES (%s, %s, %s, 'GET', '/x', 200)
+        """,
+        (shared_id, datetime.now(timezone.utc), audit_request_id),
+    )
+    pg_cursor.execute(
+        """
+        INSERT INTO audit_log (id, occurred_at, request_id, method, path, status_code)
+        VALUES (%s, %s, %s, 'GET', '/x', 200)
+        """,
+        (
+            shared_id,
+            datetime.now(timezone.utc) + timedelta(hours=1),
+            audit_request_id,
+        ),
+    )
+
+    pg_cursor.execute(
+        "SELECT COUNT(*) FROM audit_log WHERE id = %s AND request_id = %s",
+        (shared_id, audit_request_id),
+    )
+    assert pg_cursor.fetchone()[0] == 2
+
+
+def test_audit_log_time_range_query(pg_cursor, audit_request_id, audit_cleanup):
+    now = datetime.now(timezone.utc)
+
+    insert_audit_row(
+        pg_cursor, audit_request_id + "-old", occurred_at=now - timedelta(days=10)
+    )
+    insert_audit_row(
+        pg_cursor, audit_request_id + "-mid", occurred_at=now - timedelta(days=3)
+    )
+    insert_audit_row(pg_cursor, audit_request_id + "-new", occurred_at=now)
+
+    pg_cursor.execute(
+        """
+        SELECT request_id FROM audit_log
+        WHERE request_id LIKE %s
+          AND occurred_at >= %s
+        ORDER BY occurred_at
+        """,
+        (f"{audit_request_id}%", now - timedelta(days=5)),
+    )
+    rows = [row[0] for row in pg_cursor.fetchall()]
+    assert audit_request_id + "-mid" in rows
+    assert audit_request_id + "-new" in rows
+    assert audit_request_id + "-old" not in rows
+
+
+def test_audit_log_old_inserts_create_chunks(
+    pg_cursor, audit_request_id, audit_cleanup
+):
+    """Insert rows across different weeks and verify TimescaleDB places them into chunks."""
+
+    now = datetime.now(timezone.utc)
+    for weeks_ago in [1, 3, 5, 7]:
+        insert_audit_row(
+            pg_cursor,
+            f"{audit_request_id}-w{weeks_ago}",
+            occurred_at=now - timedelta(weeks=weeks_ago),
+        )
+
+    pg_cursor.execute(
+        """
+        SELECT COUNT(DISTINCT chunk_schema || '.' || chunk_name)
+          FROM timescaledb_information.chunks c
+         WHERE c.hypertable_name = 'audit_log'
+           AND range_start <= %s
+           AND range_end   >  %s - INTERVAL '8 weeks'
+        """,
+        (now, now),
+    )
+    distinct_chunks = pg_cursor.fetchone()[0]
+    assert (
+        distinct_chunks >= 2
+    ), f"Expected ≥2 chunks for spanning data, got {distinct_chunks}"
+
+
+def test_audit_log_jsonb_filter(pg_cursor, audit_request_id, audit_cleanup):
+    for i in range(3):
+        pg_cursor.execute(
+            """
+            INSERT INTO audit_log
+                (request_id, method, path, status_code, metadata)
+            VALUES (%s, 'GET', '/v1/x', 200, %s::jsonb)
+            """,
+            (f"{audit_request_id}-{i}", f'{{"env": "test", "n": {i}}}'),
+        )
+
+    pg_cursor.execute(
+        """
+        SELECT COUNT(*) FROM audit_log
+        WHERE request_id LIKE %s
+          AND metadata @> '{"env": "test"}'::jsonb
+        """,
+        (f"{audit_request_id}%",),
+    )
+    assert pg_cursor.fetchone()[0] == 3

--- a/tests/integration/test_db_crud.py
+++ b/tests/integration/test_db_crud.py
@@ -1,0 +1,197 @@
+import uuid
+import pytest
+from datetime import datetime, timezone
+
+
+@pytest.fixture
+def cleanup_clients(pg_conn):
+    """Track and delete clients created during a test."""
+    created_ids: list = []
+
+    def _track(client_id):
+        created_ids.append(str(client_id))
+
+    yield _track
+
+    if created_ids:
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM clients WHERE id = ANY(%s::uuid[])",
+                (created_ids,),
+            )
+
+
+def _create_client(cur, name: str) -> uuid.UUID:
+    cur.execute(
+        "INSERT INTO clients (name) VALUES (%s) RETURNING id",
+        (name,),
+    )
+    return cur.fetchone()[0]
+
+
+def test_clients_insert_and_read(pg_cursor, cleanup_clients):
+    name = f"test-client-{uuid.uuid4()}"
+    cid = _create_client(pg_cursor, name)
+    cleanup_clients(cid)
+
+    pg_cursor.execute("SELECT name FROM clients WHERE id = %s", (cid,))
+    assert pg_cursor.fetchone()[0] == name
+
+
+def test_clients_unique_name(pg_cursor, cleanup_clients):
+    import psycopg2
+
+    name = f"dup-client-{uuid.uuid4()}"
+    cid = _create_client(pg_cursor, name)
+    cleanup_clients(cid)
+
+    with pytest.raises(psycopg2.errors.UniqueViolation):
+        pg_cursor.execute("INSERT INTO clients (name) VALUES (%s)", (name,))
+
+
+def test_clients_updated_at_changes_on_update(pg_conn, cleanup_clients):
+    cur = pg_conn.cursor()
+    name = f"upd-client-{uuid.uuid4()}"
+    cid = _create_client(cur, name)
+    cleanup_clients(cid)
+
+    cur.execute("SELECT updated_at FROM clients WHERE id = %s", (cid,))
+    first = cur.fetchone()[0]
+
+    import time
+
+    time.sleep(0.05)
+
+    cur.execute(
+        "UPDATE clients SET name = %s WHERE id = %s",
+        (name + "-modified", cid),
+    )
+    cur.execute("SELECT updated_at FROM clients WHERE id = %s", (cid,))
+    second = cur.fetchone()[0]
+    cur.close()
+
+    assert second > first, "updated_at trigger did not fire"
+
+
+def test_api_keys_fk_to_clients(pg_cursor, cleanup_clients):
+    cid = _create_client(pg_cursor, f"akfk-{uuid.uuid4()}")
+    cleanup_clients(cid)
+
+    key_hash = "abc" * 21 + "d"
+    pg_cursor.execute(
+        """
+        INSERT INTO api_keys (client_id, key_hash, scopes, description)
+        VALUES (%s, %s, %s, %s) RETURNING id
+        """,
+        (cid, key_hash, "read", "test-key"),
+    )
+    key_id = pg_cursor.fetchone()[0]
+
+    pg_cursor.execute("DELETE FROM clients WHERE id = %s::uuid", (str(cid),))
+
+    pg_cursor.execute(
+        "SELECT COUNT(*) FROM api_keys WHERE id = %s::uuid", (str(key_id),)
+    )
+    assert pg_cursor.fetchone()[0] == 0, "api_key was not cascaded"
+
+
+def test_api_keys_orphan_insert_rejected(pg_cursor):
+    import psycopg2
+
+    fake_client_id = str(uuid.uuid4())
+    with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+        pg_cursor.execute(
+            """
+            INSERT INTO api_keys (client_id, key_hash, scopes)
+            VALUES (%s::uuid, %s, %s)
+            """,
+            (fake_client_id, "x" * 64, "read"),
+        )
+
+
+def test_resources_jsonb_metadata(pg_cursor, cleanup_clients):
+    cid = _create_client(pg_cursor, f"res-{uuid.uuid4()}")
+    cleanup_clients(cid)
+
+    pg_cursor.execute(
+        """
+        INSERT INTO resources (client_id, kind, name, metadata)
+        VALUES (%s, 'server', %s, %s::jsonb)
+        RETURNING id
+        """,
+        (cid, f"srv-{uuid.uuid4()}", '{"region": "us-east-1", "size": "m5.large"}'),
+    )
+    rid = pg_cursor.fetchone()[0]
+
+    pg_cursor.execute(
+        """
+        SELECT metadata->>'region', metadata->>'size'
+          FROM resources WHERE id = %s
+        """,
+        (rid,),
+    )
+    assert pg_cursor.fetchone() == ("us-east-1", "m5.large")
+
+
+def test_resources_gin_index_used_for_jsonb_query(pg_cursor, cleanup_clients):
+    cid = _create_client(pg_cursor, f"gin-{uuid.uuid4()}")
+    cleanup_clients(cid)
+
+    for i in range(5):
+        pg_cursor.execute(
+            """
+            INSERT INTO resources (client_id, kind, name, metadata)
+            VALUES (%s, 'server', %s, %s::jsonb)
+            """,
+            (cid, f"srv-{i}-{uuid.uuid4()}", f'{{"env": "prod", "az": "{i}"}}'),
+        )
+
+    pg_cursor.execute(
+        """
+        SELECT COUNT(*) FROM resources
+        WHERE client_id = %s
+          AND metadata @> '{"env": "prod"}'::jsonb
+        """,
+        (cid,),
+    )
+    assert pg_cursor.fetchone()[0] == 5
+
+
+def test_policy_attachment_links_policy_to_client(pg_cursor, cleanup_clients):
+    cid = _create_client(pg_cursor, f"pol-{uuid.uuid4()}")
+    cleanup_clients(cid)
+
+    pg_cursor.execute(
+        """
+        INSERT INTO policies (name, rules)
+        VALUES (%s, %s::jsonb) RETURNING id
+        """,
+        (f"policy-{uuid.uuid4()}", '{"allow": ["read"]}'),
+    )
+    pid = pg_cursor.fetchone()[0]
+
+    pg_cursor.execute(
+        """
+        INSERT INTO policy_attachments (policy_id, target_type, target_id)
+        VALUES (%s, %s, %s)
+        """,
+        (pid, "client", cid),
+    )
+
+    pg_cursor.execute(
+        """
+        SELECT p.name, p.rules->'allow'
+          FROM policies p
+          JOIN policy_attachments pa ON pa.policy_id = p.id
+         WHERE pa.target_type = 'client' AND pa.target_id = %s::uuid
+        """,
+        (str(cid),),
+    )
+    row = pg_cursor.fetchone()
+    assert row is not None
+    assert "read" in row[1]
+
+    pg_cursor.execute(
+        "DELETE FROM policy_attachments WHERE policy_id = %s::uuid", (str(pid),)
+    )
+    pg_cursor.execute("DELETE FROM policies WHERE id = %s::uuid", (str(pid),))

--- a/tests/integration/test_db_schema.py
+++ b/tests/integration/test_db_schema.py
@@ -1,0 +1,149 @@
+import pytest
+
+EXPECTED_TABLES = {
+    "schema_migrations",
+    "clients",
+    "api_keys",
+    "resources",
+    "policies",
+    "policy_attachments",
+    "audit_log",
+}
+
+
+def test_schema_migrations_table_exists(pg_cursor):
+    pg_cursor.execute("SELECT to_regclass('public.schema_migrations') IS NOT NULL")
+    assert pg_cursor.fetchone()[0] is True
+
+
+def test_both_migrations_applied(pg_cursor):
+    pg_cursor.execute("SELECT version FROM schema_migrations ORDER BY version")
+    versions = [row[0] for row in pg_cursor.fetchall()]
+    assert 1 in versions, "migration 0001 not applied"
+    assert 2 in versions, "migration 0002 not applied"
+
+
+def test_all_expected_tables_exist(pg_cursor):
+    pg_cursor.execute("""
+        SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+        """)
+    actual = {row[0] for row in pg_cursor.fetchall()}
+    missing = EXPECTED_TABLES - actual
+    assert not missing, f"Missing tables: {missing}"
+
+
+def test_clients_had_uuid_pk(pg_cursor):
+    pg_cursor.execute("""
+        SELECT column_name, data_type FROM information_schema.columns
+        WHERE table_name = 'clients' AND column_name = 'id'
+        """)
+    row = pg_cursor.fetchone()
+    assert row is not None
+    assert row[1] == "uuid"
+
+
+def test_clients_name_is_unique(pg_cursor):
+    pg_cursor.execute("""
+        SELECT COUNT(*) FROM pg_indexes
+        WHERE tablename = 'clients'
+          AND indexdef ILIKE '%UNIQUE%'
+          AND indexdef ILIKE '%(name)%'
+        """)
+    assert pg_cursor.fetchone()[0] >= 1
+
+
+def test_api_keys_fk_to_clients(pg_cursor):
+    pg_cursor.execute("""
+        SELECT COUNT(*) FROM information_schema.table_constraints
+        WHERE table_name = 'api_keys' AND constraint_type = 'FOREIGN KEY'
+        """)
+    assert pg_cursor.fetchone()[0] >= 1
+
+
+def test_api_keys_hash_column_exists(pg_cursor):
+    pg_cursor.execute("""
+        SELECT data_type FROM information_schema.columns
+        WHERE table_name = 'api_keys' AND column_name = 'key_hash'
+        """)
+    row = pg_cursor.fetchone()
+    assert row is not None, "key_hash column missing"
+    assert row[0] == "text"
+
+
+def test_resources_metadata_is_jsonb(pg_cursor):
+    pg_cursor.execute("""
+        SELECT data_type FROM information_schema.columns
+        WHERE table_name = 'resources' AND column_name = 'metadata'
+        """)
+    row = pg_cursor.fetchone()
+    assert row is not None
+    assert row[0] == "jsonb"
+
+
+def test_resources_has_gin_index(pg_cursor):
+    pg_cursor.execute("""
+        SELECT indexname FROM pg_indexes
+        WHERE tablename = 'resources' AND indexdef LIKE '%gin%'
+        """)
+    rows = pg_cursor.fetchall()
+    assert len(rows) >= 1, "resources is missing a GIN index on jsonb"
+
+
+def test_policies_rules_is_jsonb(pg_cursor):
+    pg_cursor.execute("""
+        SELECT data_type FROM information_schema.columns
+        WHERE table_name = 'policies' AND column_name = 'rules'
+        """)
+    row = pg_cursor.fetchone()
+    assert row is not None
+    assert row[0] == "jsonb"
+
+
+def test_timescaledb_extension_enabled(pg_cursor):
+    pg_cursor.execute(
+        "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'"
+    )
+    row = pg_cursor.fetchone()
+    assert row is not None, "TimescaleDB extension not installed"
+
+
+def test_audit_log_is_hypertable(pg_cursor):
+    pg_cursor.execute("""
+        SELECT hypertable_name FROM timescaledb_information.hypertables
+        WHERE hypertable_name = 'audit_log'
+        """)
+    assert pg_cursor.fetchone() is not None, "audit_log is not a hypertable"
+
+
+def test_audit_log_has_composite_pk(pg_cursor):
+    pg_cursor.execute("""
+        SELECT a.attname
+          FROM pg_index i
+          JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+         WHERE i.indrelid = 'audit_log'::regclass AND i.indisprimary
+         ORDER BY a.attnum
+        """)
+    cols = [row[0] for row in pg_cursor.fetchall()]
+    assert "id" in cols
+    assert "occurred_at" in cols
+
+
+def test_retention_policy_exists(pg_cursor):
+    pg_cursor.execute("""
+        SELECT config FROM timescaledb_information.jobs
+        WHERE proc_name = 'policy_retention'
+        """)
+    row = pg_cursor.fetchone()
+    assert row is not None, "No retention policy configured"
+    assert "90 days" in str(row[0])
+
+
+def test_clients_has_updated_at_trigger(pg_cursor):
+    pg_cursor.execute("""
+        SELECT tgname FROM pg_trigger
+        WHERE tgrelid = 'clients'::regclass AND NOT tgisinternal
+        """)
+    triggers = [row[0] for row in pg_cursor.fetchall()]
+    assert any(
+        "updated" in t for t in triggers
+    ), f"clients table missing updated_at trigger; have: {triggers}"


### PR DESCRIPTION
Closes CORV-28

- test_db_schema.py (15): tables, columns, PKs, FKs, GIN index, TimescaleDB extension, audit_log hypertable, retention policy, updated_at triggers
- test_db_audit_log.py (7): INSERT/SELECT, default occurred_at, JSONB metadata, composite PK (id, occurred_at) allows id reuse, time-range queries, chunks span weeks, JSONB containment filter
- test_db_crud.py (8): clients CRUD, unique name, updated_at trigger, api_keys FK cascade, orphan FK rejected, resources JSONB+GIN, policy_attachments via target_type/target_id
- test_cache_aside.py (14): SET/GET, TTL, EXISTS/DEL, SCAN-based prefix invalidation
- conftest.py: pg_conn/pg_cursor fixtures, UUID adapter registered
- README.md: override block exposes postgres on host port 5433